### PR TITLE
Fix forwarding with --check and --doc options

### DIFF
--- a/src/voc4cat/wrapper.py
+++ b/src/voc4cat/wrapper.py
@@ -445,6 +445,11 @@ def check(fpath, outfile):
         return 1
 
     print("All checks passed successfully.")
+
+    if fpath != outfile:  # Save to new directory (important for --forward option)
+        wb.save(outfile)
+        print(f"Saved checked file as {outfile}")
+
     return 0
 
 
@@ -698,9 +703,9 @@ def main_cli(args=None):
                 locargs.append(str(infile))
                 err += run_vocexcel(locargs)
             if args_wrapper.docs:
-                infile = Path(infile).with_suffix(".ttl") if outdir is None else outfile
+                infile = infile if outdir is None else outfile
                 doc_path = infile.parent if outdir is None else outdir
-                err += run_ontospy(infile, doc_path)
+                err += run_ontospy(infile.with_suffix(".ttl"), doc_path)
         else:
             print(
                 "Expected xlsx-file or directory but got: {0}".format(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -601,8 +601,37 @@ def test_forwarding_3stages(datadir, tmp_path, test_file):
     [CS_CYCLES, ""],
     ids=["single file", "dir of files"],
 )
+def test_forwarding_3stages_outdir(datadir, tmp_path, test_file):
+    """Check file by voc4cat, write it to output folder, forward to vocexcel & ontospy.
+
+    Related: #issue106
+    """
+    os.chdir(tmp_path)
+    main_cli(
+        [
+            "--check",
+            "--forward",
+            "--output-directory",
+            str(tmp_path),
+            "--logfile",
+            "test.log",
+            "--docs",
+            str(datadir / test_file),
+        ]
+    )
+    assert (tmp_path / CS_CYCLES).with_suffix(".ttl").exists()
+    assert (tmp_path / Path(CS_CYCLES).stem / "dendro" / "index.html").exists()
+    assert (tmp_path / Path(CS_CYCLES).stem / "docs" / "index.html").exists()
+    assert (tmp_path / "test.log").exists()
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [CS_CYCLES, ""],
+    ids=["single file", "dir of files"],
+)
 def test_forwarding_2stages(datadir, tmp_path, test_file):
-    """Use voc4cat to run vocexcel then foward result to ontospy."""
+    """Use voc4cat to run vocexcel then forward result to ontospy."""
     dst = tmp_path / test_file
     shutil.copy(datadir / CS_CYCLES, tmp_path)
     os.chdir(tmp_path)


### PR DESCRIPTION
The xlsx file was not copied if `--check` was used together with `--output-directory`. Moreover, the xlsx file was passed to ontospy not the ttl file.

Closes #106