### PR TITLE
Add config file template for vocabularies

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -22,6 +22,6 @@ Earlier template versions which are not listed here should not be used.
 
 # Vocabulary config file template "idranges.toml"
 
-With this files ranges of integer IDs can be pre-alloated to specific contributors.
-Also OCID and ROR ID can be specified for each contributor.
-The file also holds other config parameters for a vocabulary, e.g. the length of the ID.
+With this cofig file ranges of integer IDs can be pre-allocated to specific contributors.
+Also ORCID and ROR ID can be specified for each contributor.
+The file moreover holds other config parameters for a vocabulary, e.g. the length of the ID.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,8 +1,8 @@
+# Excel templates
+
 The templates here match structure-wise with the templates in [VocExcel](https://github.com/nfdi4cat/VocExcel) of the same version number.
 
-# Template version 0.4.3
-
-## Revision 2023-03a
+## Version 0.4.3, Revision 2023-03a
 
 The following is different in the voc4cat-template (`voc4cat_template_043.xlsx`):
 
@@ -16,6 +16,12 @@ The following is different in the voc4cat-template (`voc4cat_template_043.xlsx`)
 
 The identical template `voc4cat_template_043.xlsx` is included in [voc4cat-tool/templates](https://github.com/nfdi4cat/voc4cat-template/tree/main/templates).
 
-# Earlier template versions
+## Earlier Excel template versions
 
 Earlier template versions which are not listed here should not be used.
+
+# Vocabulary config file template "idranges.toml"
+
+With this files ranges of integer IDs can be pre-alloated to specific contributors.
+Also OCID and ROR ID can be specified for each contributor.
+The file also holds other config parameters for a vocabulary, e.g. the length of the ID.

--- a/templates/idranges.toml
+++ b/templates/idranges.toml
@@ -1,0 +1,29 @@
+# Documentation of the TOML format: https://toml.io/en/latest
+
+# Length of integer IDs in vocabulary. IDs will be left-padded with zeros to specified length.
+id_length = 8
+
+# Section of IDranges for coordinating the allocation of numeric ID ranges to
+# contributors for each vocabulary. Each idrange contains the same keys:
+#
+#   first_id = <int>              - first reserved integer ID in idrange
+#   last_id = <int>               - last reserved integer ID in idrange
+#   gh_username = "<string>"      - username on github
+#   orcid = "<string>"            - contributor's ORCID, e.g. "0000-0001-2345-6789"
+#   organisation_ror_id = "<url>" - ROR of home organisation, e.g. "https://ror.org/04fa4r544"
+
+[[idrange]]
+first_id = 1
+last_id = 10
+gh_username = "sofia-garcia"
+orcid = "0000-0001-2345-6789"
+organisation_ror_id = "https://ror.org/04fa4r544"
+
+[[idrange]]
+first_id = 11
+last_id = 20
+gh_username = "n.n."
+orcid = ""
+organisation_ror_id = ""
+
+# Continue with as many [[idrange]] sections as needed.


### PR DESCRIPTION
_Marked as draft, because https://github.com/nfdi4cat/voc4cat/pull/8 should be completed first._

This config file of a vocabulary allows to specify

* Ranges of integer IDs that are pre-allocated to specific contributors
* ORCID and ROR ID for each contributor.
* Additional config parameters for a vocabulary , e.g. the length of the ID. Only parameters that are not specified in the Excel-file and turtle-vocabulary file should be considered for inclusion in the config file.

Closes #108
Closes #109