### PR TITLE
Support pyLODE as documentation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To support what is not provided by the original VocExcel project we have develop
 - Checking our NFDI4Cat-Excel template
 - Enriching our NFDI4Cat-Excel template (e.g. add IRIs)
 - Processing all files in a folder at once
-- Generating documentation (with [ontospy](http://lambdamusic.github.io/Ontospy/))
+- Generating documentation (with [pyLODE](https://github.com/RDFLib/pyLODE) or [ontospy](http://lambdamusic.github.io/Ontospy/))
 - Support for expressing concept-hierarchies by indentation.
 
 Since mid 2022 voc4cat should be used with our VocExcel fork [nfdi4cat/VocExcel](https://github.com/nfdi4cat/VocExcel). The original project (now at [RDFlib/VocExcel](https://github.com/RDFLib/VocExcel)) changed its templates substantially which made it too cumbersome to keep our code and the customized templates compatible.
@@ -111,7 +111,7 @@ It is also possible to create an xlsx file from a turtle file. Optionally a cust
 Options that are specific for VocExcel can be put at the end of a `voc4cat` command.
 Here is an example that forwards the `-e 3` and `-m 3` options to VocExcel and moreover demonstrates a complex combination of options (as used in CI):
 
-`voc4cat --check --forward --docs --output-directory outbox inbox-excel-vocabs/ -e 3 -m 3`
+`voc4cat --check --forward --docs pylode --output-directory outbox inbox-excel-vocabs/ -e 3 -m 3`
 
 ## Feedback and code contributions
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
-Example files showing what voc4cat can do:
+Example files showing typical conversions with voc4cat:
 
 - `Photocatalysis_LIKAT_template043_orig-fixed.xlsx`
   - A draft of a photocatalysis vocabulary: This has still the original structure and contents; only spelling and link errors were fixed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "openpyxl >= 3.0.9",
   "pillow >= 9.1.0",
   "ontospy >= 2.1.0",
+  "pyLODE < 3.0.0",
 ]
 
 #dynamic = ["version", "readme"]

--- a/vocabularies/README.md
+++ b/vocabularies/README.md
@@ -1,1 +1,1 @@
-Directory to collect the vocabularies in rdf/turtle format that were created using the vocexcel4cat workflow and its CI/CD pipeline.
+Directory to collect the vocabularies in rdf/turtle format that were created using the voc4cat-workflow and its CI/CD pipeline.


### PR DESCRIPTION
The `--docs` option was changed to accept an argument: Use `--docs pylode` to generate the documentation with pyLODE 2.x and `--docs ontospy` to generate the documentation with ontospy.

This PR also reverts parts of #113: It switches ontospy back to generate single-page html docs which are more usable than the multi-page version (for voc4cat).

Closes #114