### PR TITLE
Refactor validation with pydantic & add curies for converting between URI and CURIE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,15 @@ classifiers = [
 ]
 
 dependencies = [
+  "curies >= 0.5.6",
   "networkx >= 2.8",
   "openpyxl >= 3.0.9",
-  "pillow >= 9.1.0",
   "ontospy >= 2.1.0",
-  "pyLODE < 3.0.0",
-  "rdflib >= 6.1.1",
+  "pillow >= 9.1.0",
   "pydantic < 2.0.0",
+  "pyLODE < 3.0.0",
   "pyshacl >= 0.18.1",
+  "rdflib >= 6.1.1",
 ]
 
 #dynamic = ["version", "readme"]
@@ -221,7 +222,7 @@ select = [
     "SIM", # flake8-simplify
     # flake8-unused-arguments (ARG)
     # flake8-use-pathlib (PTH)
-    # eradicate (ERA) - commented out code
+    # "ERA", # eradicate (ERA) - commented out code
     # pandas-vet (PD)
     "PGH", # pygrep-hooks
     "PL",  # whole Pylint (Convention, Error, Refactor, Warning)

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -8,18 +8,6 @@ from voc4cat import models
 from voc4cat.utils import ConversionError, split_and_tidy
 
 
-# Checking how many colon's in string
-def only_one_colon_in_str(string):
-    counter = 0
-    for character in string:
-        if character == ":":
-            counter += 1
-    if counter != 1:
-        return False
-    return True
-
-
-# function in creating a dictionary / recalling from a dictionary.
 def create_prefix_dict(s: Worksheet):
     # create an empty dict
     prefix_dict = {}
@@ -38,48 +26,6 @@ def create_prefix_dict(s: Worksheet):
                 msg = f"Prefix processing error, sheet {s}, row {row}, error: {exc}"
                 raise ConversionError(msg) from exc
     return prefix_dict
-
-
-# prefix and namespace use without list output
-def using_prefix_and_namespace_non_list_output(cell_value, prefix, s: Worksheet, row):
-    c = cell_value
-    if c is not None:
-        if c.startswith(("http://", "https://")):
-            pass
-        elif only_one_colon_in_str(c):
-            split_c_prefix = c.split(":")[0]
-            split_c_added_component = c.split(":")[1]
-
-            if split_c_prefix in prefix:
-                c = prefix[split_c_prefix] + split_c_added_component
-            else:
-                msg = f"The prefix '{split_c_prefix}' used in sheet {s} and row {row} isn't included in the prefix sheet."
-                raise ConversionError(msg)
-        else:
-            msg = f"Something doesn't look right on row {row} and sheet {s}. The problematic cell value is '{c}'. Correct URL form used?"
-            raise ConversionError(msg)
-    return c
-
-
-# specifically just for concept scheme
-def using_prefix_and_namespace_cs(cell_value, prefix):
-    c = cell_value
-    if c is not None:
-        if c.startswith(("http://", "https://")):
-            pass
-        elif only_one_colon_in_str(c):
-            split_c_prefix = c.split(":")[0]
-            split_c_added_component = c.split(":")[1]
-
-            if split_c_prefix in prefix:
-                c = prefix[split_c_prefix] + split_c_added_component
-            else:
-                msg = f"The prefix '{split_c_prefix}' used in the concept scheme pageisn't included in the prefix sheet."
-                raise ConversionError(msg)
-        else:
-            msg = "Something doesn't look right in the concept scheme page. The problematic cell value is '{c}'. Correct URL form used?"
-            raise ConversionError(msg)
-    return c
 
 
 def extract_concepts_and_collections(

--- a/src/voc4cat/util.py
+++ b/src/voc4cat/util.py
@@ -130,7 +130,6 @@ def dag_to_node_levels(termgraph, baselevel=0):
 
     node_levels = []
     for subgraph in subgraphs:
-        # print(f"\nsubgraph: {subgraph}")
         # We need a clean subgraph without cylces for creating an indented tree.
         subgraph_clean = subgraph.copy()
         subgraph_clean.remove_edges_from(broken_edges)

--- a/src/voc4cat/utils.py
+++ b/src/voc4cat/utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List, Tuple
 
 from openpyxl import load_workbook as _load_workbook
 from openpyxl.workbook.workbook import Workbook
@@ -15,7 +14,7 @@ RDF_FILE_ENDINGS = {
     ".n3": "n3",
 }
 KNOWN_FILE_ENDINGS = [str(x) for x in RDF_FILE_ENDINGS] + EXCEL_FILE_ENDINGS
-KNOWN_TEMPLATE_VERSIONS = ["0.2.1", "0.3.0", "0.4.0", "0.4.1", "0.4.2", "0.4.3"]
+KNOWN_TEMPLATE_VERSIONS = ["0.4.0", "0.4.1", "0.4.2", "0.4.3"]
 LATEST_TEMPLATE = KNOWN_TEMPLATE_VERSIONS[-1]
 
 
@@ -61,33 +60,3 @@ def split_and_tidy(cell_value: str):
         return []
     entries = [x.strip() for x in cell_value.strip().split(",")]
     return [x for x in entries if x]
-
-
-def string_is_http_iri(s: str) -> Tuple[bool, str]:
-    # returns (True, None) if the string (sort of) is an IRI
-    # returns (False, message) otherwise
-    messages = []
-    if not s.startswith("http"):
-        messages.append("HTTP IRIs must start with 'http' or 'https'")
-
-    if " " in s:
-        messages.append("IRIs cannot contain spaces")
-
-    if len(messages) > 0:
-        return False, " and ".join(messages)
-
-    return True, ""
-
-
-def all_strings_in_list_are_iris(l_: List) -> Tuple[bool, str]:
-    messages = []
-    if l_ is not None:
-        for item in l_:
-            r = string_is_http_iri(item)
-            if not r[0]:
-                messages.append(f"Item {item} failed with messages {r[1]}")
-
-    if len(messages) > 0:
-        return False, " and ".join(messages)
-
-    return True, ""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic.error_wrappers import ValidationError
-from voc4cat.models import *
+from rdflib import Graph
+from voc4cat.models import Concept, ConceptScheme
 
 
 def test_vocabulary_valid():
@@ -78,7 +79,6 @@ def test_concept():
     # definition
     # def_language_code
     # children
-    # other_ids
     # home_vocab_uri
     # provenance
     c = Concept(
@@ -86,14 +86,12 @@ def test_concept():
         pref_label="Thing X",
         definition="Fake def for Thing X",
         children=["https://example.com/thing/y", "https://example.com/thing/z"],
-        other_ids=["XX", "XXX"],
         close_match=[
             "https://example.com/thing/other",
             "https://example.com/thing/otherother",
         ],
     )
     actual = c.to_graph()
-    print(actual)
     expected = Graph().parse(
         data="""@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
         @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -104,10 +102,10 @@ def test_concept():
     skos:closeMatch <https://example.com/thing/other>, <https://example.com/thing/otherother> ;
     skos:definition "Fake def for Thing X"@en ;
     skos:narrower <https://example.com/thing/y>, <https://example.com/thing/z> ;
-    skos:notation "XX", "XXX" ;
     dcterms:identifier "x"^^xsd:token ;
     skos:prefLabel "Thing X"@en ."""
     )
+
     assert actual.isomorphic(expected)
 
 
@@ -120,7 +118,6 @@ def test_concept_iri():
     # definition
     # def_language_code
     # children
-    # other_ids
     # home_vocab_uri
     # provenance
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Refactor how validation with pydantic is performed according to #125. 

This also adds using the [curies](https://github.com/cthoyt/curies) package to convert from CURIE to URI and back. By making better use of pydantic´s features some functions could be removed which increased coverage without adding any tests.

Closes #125