### PR TITLE
Use CURIES when converting rdf->xlsx, export used prefixes to xlsx (& new config-handling)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-yaml
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     -   id: black
         args: ['--target-version', 'py38']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,3 +241,7 @@ target-version = "py38"
 [tool.ruff.mccabe]
 # Flake8-mccabe uses a default level of 7, ruff of 10.
 max-complexity = 10
+
+[tool.ruff.pep8-naming]
+# Allow Pydantic's `@validator` decorator to trigger class method treatment.
+classmethod-decorators = ["classmethod", "pydantic.validator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "pyLODE < 3.0.0",
   "pyshacl >= 0.18.1",
   "rdflib >= 6.1.1",
+  "tomli>=1.1.0; python_version < '3.11'",
 ]
 
 #dynamic = ["version", "readme"]

--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -1,0 +1,25 @@
+# This module is used to share the configuration in across voc4cat.
+
+from pathlib import Path
+
+import tomllib
+from curies import Converter
+from rdflib import Graph
+from rdflib.namespace import NamespaceManager
+
+VOCAB_TITLE = ""
+CONFIG_FILE = Path("idranges.toml").resolve()
+
+def load_config(fp:Path):
+    with fp.open(mode="rb") as fp:
+        return tomllib.load(fp)
+
+idranges = load_config(CONFIG_FILE) if CONFIG_FILE.exists() else {}
+
+namespace_manager = NamespaceManager(Graph())
+# Initialize curies-converter with default namespace of rdflib.Graph
+curies_converter = Converter.from_prefix_map(
+    {prefix: str(url) for prefix, url in namespace_manager.namespaces()}
+)
+
+# TODO Use pydantic for validation of idranges.toml content or https://gitlab.com/sscherfke/typed-settings

--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -1,11 +1,16 @@
 # This module is used to share the configuration in across voc4cat.
 
+import sys
 from pathlib import Path
 
-import tomllib
 from curies import Converter
 from rdflib import Graph
 from rdflib.namespace import NamespaceManager
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 VOCAB_TITLE = ""
 CONFIG_FILE = Path("idranges.toml").resolve()

--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -10,9 +10,11 @@ from rdflib.namespace import NamespaceManager
 VOCAB_TITLE = ""
 CONFIG_FILE = Path("idranges.toml").resolve()
 
-def load_config(fp:Path):
+
+def load_config(fp: Path):
     with fp.open(mode="rb") as fp:
         return tomllib.load(fp)
+
 
 idranges = load_config(CONFIG_FILE) if CONFIG_FILE.exists() else {}
 

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -393,6 +393,9 @@ def rdf_to_excel(
         ).to_excel(wb, row_no)
         row_no += 1
 
+    # Write the prefix_map used in the conversion to the prefix sheet.
+    write_prefix_sheet(wb, config.curies_converter.prefix_map)
+
     # Store title in config (re-used in ontospy docs generation)
     config.VOCAB_TITLE = cs.title
 

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -1,6 +1,7 @@
 from typing import List, Tuple
 
 from curies import Converter
+from openpyxl import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from pydantic import ValidationError
 
@@ -26,6 +27,19 @@ def create_prefix_dict(s: Worksheet):
                 msg = f"Prefix processing error, sheet {s}, row {row}, error: {exc}"
                 raise ConversionError(msg) from exc
     return prefix_dict
+
+
+def write_prefix_sheet(wb: Workbook, prefix_map):
+    """
+    Write prefix_dict to prefix sheet
+    """
+    ws = wb["Prefix Sheet"]
+
+    # Clear the sheet except for the header.
+    ws.delete_rows(2, ws.max_row - 1)
+
+    for prefix, iri in prefix_map.items():
+        ws.append([prefix, iri])
 
 
 def extract_concepts_and_collections(

--- a/src/voc4cat/wrapper.py
+++ b/src/voc4cat/wrapper.py
@@ -11,12 +11,9 @@ from warnings import warn
 
 import openpyxl
 from openpyxl.styles import Alignment, PatternFill
-from rdflib import URIRef
 
-import voc4cat
-from voc4cat import __version__
+from voc4cat import __version__, config
 from voc4cat.convert import main as vocexcel_main
-from voc4cat.models import ORGANISATIONS, ORGANISATIONS_INVERSE
 from voc4cat.util import (
     dag_from_indented_text,
     dag_from_narrower,
@@ -25,10 +22,6 @@ from voc4cat.util import (
     get_concept_and_level_from_indented_line,
 )
 from voc4cat.utils import EXCEL_FILE_ENDINGS, KNOWN_FILE_ENDINGS, RDF_FILE_ENDINGS
-
-ORGANISATIONS["NFDI4Cat"] = URIRef("http://example.org/nfdi4cat/")
-ORGANISATIONS["LIKAT"] = URIRef("https://www.catalysis.de/")
-ORGANISATIONS_INVERSE.update({v: k for k, v in ORGANISATIONS.items()})
 
 
 def is_file_available(fname, ftype):
@@ -396,7 +389,7 @@ def run_ontospy(file_path, output_path):
         return 1
 
     for turtle_file in turtle_files:
-        title = voc4cat.convert.VOCAB_TITLE
+        title = config.VOCAB_TITLE
 
         print(f"\nBuilding ontospy documentation for {turtle_file}")
         specific_output_path = (Path(output_path) / Path(turtle_file).stem).resolve()

--- a/templates/idranges.toml
+++ b/templates/idranges.toml
@@ -7,13 +7,17 @@ single_vocab = true
 
 # ==== Configuration for vocabulary "voc4cat" ====
 
-[[myvocab]]
+[myvocab]
 # Length of integer IDs in vocabulary. IDs will be left-padded with zeros to specified length.
 id_length = 7
 
 # Section to configure checks (useful in CI pipeline)
-[[myvocab.checks]]
+[myvocab.checks]
 no_delete = true
+
+[myvocab.prefix_map]
+ex = "https://example.org/"
+photo = "https://example.org/nfdi4cat/photo/"
 
 # Section of IDranges for coordinating the allocation of numeric ID ranges to
 # contributors for each vocabulary. Each idrange contains the same keys:


### PR DESCRIPTION
This PR brings
- A central configuration-handling via `config.py` file/module that reads `idranges.toml`. This module `config.py` is then imported wherever the configuration is needed.
- A simplification and extension of the data structure in `idranges.toml`. New part: A prefix-map for the vocabulary. These prefixes are used when creating an xlsx-file from rdf.
- CURIES are now preferably used when creating xlsx files (instead of URIs).
- As part of the `rdf2excel`-call the used prefixes are now exported to the "Prefix sheet".

Closes #121
Closes #123