### PR TITLE
Improve use of logging framework

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,7 @@ Example files showing typical conversions with voc4cat:
   - A draft of a photocatalysis vocabulary: This has still the original structure and contents; only spelling and link errors were fixed.
   - The hierarchy was created with voc4cat 0.30 by the `-r` / `--add-related` option from the extra column on the right in sheets Concepts & Collections. Note, this option was removed in 0.4.0 to foster using numeric IDs.
 - `Photocatalysis_LIKAT_template043_textids.xlsx`
-  - Same contents as the first file but the extra column in the sheets Concepts & Collections was removed. The concepts were sorted by IRI (this was done to assign IDs in a reproducible way to domonstrate round-tripping, see below).
+  - Same contents as the first file but the extra column in the sheets Concepts & Collections was removed. The concepts were sorted by IRI (this was done to assign IDs in a reproducible way to demonstrate round-tripping, see below).
 - `Photocatalysis_LIKAT_template043_final.xlsx`
   - This file was generate from the previous one by replacing the textual IDs with numeric ones using the `--make-ids` option added in version 0.4.0.
 - `Photocatalysis_LIKAT_template043_final.ttl`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,7 @@ max-complexity = 10
 classmethod-decorators = ["classmethod", "pydantic.validator"]
 
 [tool.codespell]
-skip = "pyproject.toml,./vocabularies,./example,./tests/data,./tmp"
+skip = "*.xlsx,pyproject.toml,./vocabularies,./example,./tests/data,./tmp"
 # Note: words have to be lowercased for the ignore-words-list
 ignore-words-list = "linke"
 quiet-level = 3

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -541,6 +541,7 @@ def main(args=None):
     if args.logfile:
         # We import here to avoid a cyclic import when this is used via wrapper.main
         from voc4cat.wrapper import setup_logging
+
         setup_logging(logfile=args.logfile)
     elif run_via_entrypoint:
         setup_logging()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -442,30 +443,31 @@ def test_build_docs_ontospy(datadir, tmp_path, test_file):
     "doc_builder",
     ["pylode", "ontospy"],
 )
-def test_build_docs(tmp_path, capsys, doc_builder):
+def test_build_docs(tmp_path, caplog, doc_builder):
     """Check handling of missing dir/file on documentation build."""
-    exit_code = build_docs(tmp_path, tmp_path, doc_builder)
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        exit_code = build_docs(tmp_path, tmp_path, doc_builder)
     assert exit_code == 1
-    assert f"No turtle file(s) found to document in {tmp_path}" in captured.out
-    exit_code = build_docs(tmp_path / CS_CYCLES_TURTLE, tmp_path, doc_builder)
-    captured = capsys.readouterr()
+    assert f"No turtle file(s) found to document in {tmp_path}" in caplog.text
+
+    with caplog.at_level(logging.INFO):
+        exit_code = build_docs(tmp_path / CS_CYCLES_TURTLE, tmp_path, doc_builder)
     assert exit_code == 1
-    assert f"File/dir not found (for docs): {tmp_path/CS_CYCLES_TURTLE}" in captured.out
+    assert f"File/dir not found (for docs): {tmp_path/CS_CYCLES_TURTLE}" in caplog.text
 
-    exit_code = build_docs(tmp_path / CS_CYCLES_TURTLE, tmp_path, "ontospy")
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        exit_code = build_docs(tmp_path / CS_CYCLES_TURTLE, tmp_path, "ontospy")
     assert exit_code == 1
-    assert f"File/dir not found (for docs): {tmp_path/CS_CYCLES_TURTLE}" in captured.out
+    assert f"File/dir not found (for docs): {tmp_path/CS_CYCLES_TURTLE}" in caplog.text
 
 
-def test_build_docs_unknown_builder(tmp_path, capsys):
+def test_build_docs_unknown_builder(tmp_path, caplog):
     """Check handling of unknown documentation builder."""
     unknown_doc_builder = "123doc"
-    exit_code = build_docs(tmp_path, tmp_path, unknown_doc_builder)
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.INFO):
+        exit_code = build_docs(tmp_path, tmp_path, unknown_doc_builder)
     assert exit_code == 1
-    assert f"Unsupported document builder '{unknown_doc_builder}'." in captured.out
+    assert f"Unsupported document builder '{unknown_doc_builder}'." in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -481,14 +483,14 @@ def test_build_docs_unknown_builder(tmp_path, capsys):
     ],
     ids=["no error", "with error"],
 )
-def test_check(datadir, tmp_path, capsys, test_file, err, msg):  # noqa: PLR0913
+def test_check(datadir, tmp_path, caplog, test_file, err, msg):  # noqa: PLR0913
     dst = tmp_path / test_file
     shutil.copy(datadir / test_file, dst)
-    exit_code = main_cli(["--check", "--no-warn", str(dst)])
-    captured = capsys.readouterr()
-    # TODO check that erroneous cells get colored.
+    with caplog.at_level(logging.INFO):
+        exit_code = main_cli(["--check", "--no-warn", str(dst)])
     assert exit_code == err
-    assert msg in captured.out
+    assert msg in caplog.text
+    # TODO check that erroneous cells get colored.
 
 
 def test_unsupported_filetype(datadir, capsys):


### PR DESCRIPTION
For setting up the logging framework a new function setup_logging(...) was created.

Still to do:
- [x] Go through print() statements and replace by logging where it [makes sense](https://docs.python.org/3/howto/logging.html#when-to-use-logging).

Closes #28