### PR TITLE
New cli with subcommands

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ from importlib.metadata import version
 # -- Project information -----------------------------------------------------
 
 project = "voc4cat"
-copyright = "2022, David Linke"
+copyright = "2022, David Linke"  # noqa: A001
 author = "David Linke"
 
 # The full version, including alpha/beta/rc tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ branch = true
 source = ["voc4cat"]
 omit = [
     "**/voc4cat/_version.py",
-    "**/voc4cat/cli.py"  # in early development
 ]
 
 [tool.coverage.paths]
@@ -224,8 +223,8 @@ select = [
     "Q",   # flake8-quotes
     "RET", # flake8-return
     "SIM", # flake8-simplify
-    # flake8-unused-arguments (ARG)
-    # flake8-use-pathlib (PTH)
+    # "ARG", # flake8-unused-arguments (ARG)
+    # "PTH", # flake8-use-pathlib (PTH)
     # "ERA", # eradicate (ERA) - commented out code
     # pandas-vet (PD)
     "PGH", # pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dev = [
 
 [project.scripts]
 voc4cat = "voc4cat.wrapper:main_cli"
-voc4cat-ng = "voc4cat.cli:start_cli_app"
+voc4cat-ng = "voc4cat.cli:run_cli_app"
 vocexcel = "voc4cat.convert:main"
 merge_vocab = "voc4cat.merge_vocab:main_cli"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
 
 [project.scripts]
 voc4cat = "voc4cat.wrapper:main_cli"
+voc4cat-ng = "voc4cat.cli:start_cli_app"
 vocexcel = "voc4cat.convert:main"
 merge_vocab = "voc4cat.merge_vocab:main_cli"
 
@@ -144,6 +145,7 @@ branch = true
 source = ["voc4cat"]
 omit = [
     "**/voc4cat/_version.py",
+    "**/voc4cat/cli.py"  # in early development
 ]
 
 [tool.coverage.paths]

--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -1,0 +1,90 @@
+import glob
+import logging
+from pathlib import Path
+
+from voc4cat import profiles
+from voc4cat.checks import (
+    Voc4catError,
+    check_for_removed_iris,
+    check_number_of_files_in_inbox,
+    validate_vocabulary_files_for_ci_workflow,
+)
+from voc4cat.convert import validate_with_profile
+from voc4cat.utils import EXCEL_FILE_ENDINGS, RDF_FILE_ENDINGS
+from voc4cat.wrapper import check as check_xlsx
+
+logger = logging.getLogger(__name__)
+
+
+def _check_ci_args(args):
+    msg = ""
+    if args.ci_pre:
+        if args.VOCAB and args.VOCAB.is_dir() and args.ci_pre.is_dir():
+            return
+        msg = "Need two dirs for ci_pre!"
+    if args.ci_post:
+        if args.VOCAB and args.VOCAB.is_dir() and args.ci_post.is_dir():
+            return
+        msg = "Need two dirs for ci_post!"
+    if msg:
+        logging.error(msg)
+        raise Voc4catError(msg)
+
+
+def check(args):
+    logger.info("Check subcommand started!")
+
+    _check_ci_args(args)
+
+    if args.listprofiles:
+        s = "\nProfiles\nToken\tIRI\n-----\t-----\n"
+        for k, v in profiles.PROFILES.items():
+            s += f"{k}\t{v.uri}\n"
+        print(s.rstrip())
+        return
+
+    if args.ci_pre:
+        inbox_dir, vocab_dir = args.ci_pre, args.VOCAB
+        check_number_of_files_in_inbox(inbox_dir)
+        validate_vocabulary_files_for_ci_workflow(vocab_dir, inbox_dir)
+        return
+
+    if args.ci_post:
+        prev_vocab_dir, vocab_new = args.ci_post, args.VOCAB
+        for vocfile in glob.glob(str(vocab_new.resolve() / "*.ttl")):
+            new = Path(vocfile)
+            vocfile_name = Path(vocfile).name
+            prev = prev_vocab_dir / vocfile_name
+            if not prev.exists():
+                logger.debug(
+                    '-> previous version of vocabulary "%s" does not exist.',
+                    vocfile_name,
+                )
+                continue
+            check_for_removed_iris(prev, new)
+        return
+
+    files = [args.VOCAB] if args.VOCAB.is_file() else [*Path(args.VOCAB).iterdir()]
+    xlsx_files = [f for f in files if f.suffix.lower() in EXCEL_FILE_ENDINGS]
+    rdf_files = [f for f in files if f.suffix.lower() in RDF_FILE_ENDINGS]
+
+    # check xlsx files
+    for file in xlsx_files:
+        outfile = file if args.outdir is None else args.outdir / file.name
+        if outfile == file and not args.inplace:
+            logger.warning(
+                'This command will overwrite the existing file "%s".'
+                'Use the flag "--inplace" to enforce replacement or '
+                'supply an output directory with flag "--outdir".',
+                file,
+            )
+            return
+        check_xlsx(file, outfile)
+
+    # validate rdf files with profile/pyshacl
+    for file in rdf_files:
+        logger.info("Running SHACL validation for file %s", file)
+        validate_with_profile(
+            str(file), profile=args.profile, error_level=args.fail_at_level
+        )
+        logger.info("-> The file is valid according to the %s profile.", args.profile)

--- a/src/voc4cat/cli.py
+++ b/src/voc4cat/cli.py
@@ -1,77 +1,400 @@
-"""New command line interface for voc4cat with subcommands"""
+"""New cleaner command line interface for voc4cat with subcommands."""
 
 import argparse
 import logging
 import sys
+import textwrap
+from pathlib import Path
 
+from voc4cat import setup_logging
 from voc4cat.checks import Voc4catError
 
 logger = logging.getLogger(__name__)
 
 
-def main_cli(args=None):
+def transform(args):
+    print("Transform subcommand executed!")
+    print(f"args: {args!r}")
+
+
+def convert(args):
+    print("Convert subcommand executed!")
+    print(f"args: {args!r}")
+
+
+def check(args):
+    print("Check subcommand executed!")
+    print(f"args: {args!r}")
+
+
+def docs(args):
+    print("Docs subcommand executed!")
+    print(f"args: {args!r}")
+
+
+class DecentFormatter(argparse.HelpFormatter):
     """
-    _summary_
-
-    _extended_summary_
-
-    Parameters
-    ----------
-    args : _type_, optional
-        _description_, by default None
-
-    Possible command structure:
-
-    voc4cat
-    <subcommands>
-    -V --version
-    -H --help
-    -v -vv --verbose
-    -q -qq  --quiet
-    -l --logfile
-    --force (was: --no-warn)        here or better on subcmds?
-    -O --outputdir   here or better on subcmds?
-
-    transform                     Conversions with xlsx files as input and output
-        file-to-process
-        --make-ids prefix start-ID  Specify prefix to search and replace by ID-based vocabulary IRIs. ...
-        --hierarchy-from-indent     Convert concept sheet with indentation to children-URI hierarchy.
-        --hierarchy-to-indent       Convert concept sheet from children-URI hierarchy to indentation.
-        --indent-separator          Separator character(s) to read/write indented hierarchies (default: xlsx indent)
-
-    convert     Convert between rdf and xlsx and back.
-        file-to-process
-        --rdf-format  xml, turtle, json-ld   Output format of generated rdf.
-        --output-type screen/file       Where to output generated rdf.
-        --template  Path to xlsx template to be used when converting to xlsx.
-
-    docs        Documentation generation from rdf
-        file-to-process
-
-    check       Validation and checks
-        file-to-process
-        --xlsx
-        --ci
-        --shacl
-        --listprofiles
-        -p --profile    Profile name or file (implies --shacl = True)
-
+    An argparse formatter that preserves newlines & keeps indentation.
     """
+
+    def _fill_text(self, text, width, indent):
+        """
+        Reformat text while keeping newlines for lines shorter than width.
+        """
+        lines = []
+        for line in textwrap.indent(textwrap.dedent(text), indent).splitlines():
+            lines.append(textwrap.fill(line, width, subsequent_indent=indent))
+        return "\n".join(lines)
+
+    def _split_lines(self, text, width):
+        """
+        Conserve indentation in help/description lines when splitting long lines.
+        """
+        lines = []
+        for line in textwrap.dedent(text).splitlines():
+            if not line.strip():
+                continue
+            indent = " " * (len(line) - len(line.lstrip()))
+            lines.extend(
+                textwrap.fill(line, width, subsequent_indent=indent).splitlines()
+            )
+        return lines
+
+
+def create_root_parser():
     parser = argparse.ArgumentParser(
-        prog="voc4cat-ng", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        prog="voc4cat-ng",
+        description="Next generation of command line interface for voc4cat-tool.",
+        allow_abbrev=False,
+        formatter_class=DecentFormatter,
     )
+    parser.add_argument(
+        "-V",
+        "--version",
+        help="The version of voc4cat command line interface.",
+        action="store_true",
+    )
+    return parser
 
-def start_cli_app(args=None):
-    if args is None:  # app started via entrypoint
+
+def create_common_options_parser():
+    parser = argparse.ArgumentParser(
+        prog="voc4cat-ng",
+        description="Next generation of command line interface for voc4cat-tool.",
+        allow_abbrev=False,
+        add_help=False,
+        formatter_class=DecentFormatter,
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        dest="verboser",
+        default=0,
+        help="Make output more verbose. Repeat to increase verbosity (-vv or -vvv).",
+    )
+    group.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        dest="quieter",
+        help="Make output less verbose. Repeat to decrease verbosity (-qq or -qqq).",
+    )
+    parser.add_argument(
+        "--config",
+        help=('Path to config file (typically "idranges.toml").'),
+        type=Path,
+        required=False,
+    )
+    parser.add_argument(
+        "-l",
+        "--logfile",
+        help=(
+            "Activate logging to a file at given path. "
+            "The path will be created if it is not existing."
+        ),
+        type=Path,
+    )
+    # We set a do-nothing func here so that we can call func for all parsers below.
+    parser.set_defaults(func=lambda _: None)
+    return parser
+
+
+def add_transform_subparser(subparsers, options):
+    """Transforms have the same input and output filetype."""
+    parser = subparsers.add_parser(
+        "transform",
+        description=(  # used in subcmd help
+            "Transforms have the same input and output filetype. By default a "
+            "transform will not overwrite existing files. To enforce replacing "
+            'existing files run with "--inplace" flag. Alternatively, supply an '
+            "output directory with -O / --outdir flag."
+        ),
+        help=(  # used in help of root parser
+            "Transform data. Transforms have the same input and output filetype."
+        ),
+        **options,
+    )
+    parser.add_argument(
+        "-O",
+        "--outdir",
+        help=(
+            "Specify directory where files should be written to. "
+            "The directory is created if required."
+        ),
+        metavar=("DIRECTORY"),
+        type=Path,
+    )
+    parser.add_argument(
+        "--make-ids",
+        help=(
+            "Specify prefix or mapping prefix:base-uri and first ID to use. "
+            'An example for a prefix-mapping is "ex:https://example.org/". '
+            "If only the prefix is given without a base-URI part "
+            "the concept-scheme URI is used as base-URI to append the IDs to.\n"
+            "The default length of the ID is 7 digits. It can be changed "
+            "via a config-file."
+        ),
+        nargs=2,
+        metavar=("PREFIX-MAPPING", "START-ID"),
+        type=str,
+    )
+    parser.add_argument(
+        "--hierarchy-from-indent",
+        help=("Convert concept sheet with indentation to children-URI hierarchy."),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--hierarchy-to-indent",
+        help=("Convert concept sheet from children-URI hierarchy to indentation."),
+        action="store_true",
+    )
+    parser.add_argument(
+        "--indent",
+        help=(
+            "Separator character(s) to read/write indented hierarchies "
+            'or "xlsx" to use xlsx-indent. (default: "xlsx")'
+        ),
+        default="xlsx",
+        type=str,
+        metavar=("SEPARATOR",),
+    )
+    parser.add_argument(
+        "--inplace",  # was "--no-warn"
+        help=(
+            "Transform file(s) in place. Replaces the input file(s) with the transformed output file(s)."
+        ),
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "VOCAB",
+        nargs=1,  # allow 0 or 1 file name as argument
+        type=Path,
+        help="Either the file to process or a directory with files to process.",
+    )
+    parser.set_defaults(func=transform)
+
+
+def add_convert_subparser(subparsers, options):
+    """Conversions xlsx <-> rdf and between different rdf representations."""
+
+    parser = subparsers.add_parser(
+        "convert",
+        description=(
+            "Convert data from xlsx to rdf and back or between different "
+            "rdf representations."
+        ),
+        help=(
+            "Convert data from xlsx to rdf, rdf to xlsx or and between different "
+            "rdf representations."
+        ),
+        **options,
+    )
+    parser.add_argument(
+        "-O",
+        "--outdir",
+        help=(
+            "Specify directory where files should be written to. "
+            "The directory is created if required."
+        ),
+        metavar=("DIRECTORY"),
+        type=Path,
+    )
+    parser.add_argument(
+        "--outputformat",
+        help=(
+            "An optionally-provided output format for RDF files. Only relevant in "
+            "Excel-to-RDf conversions. (default: turtle)"
+        ),
+        required=False,
+        choices=["turtle", "xml", "json-ld"],
+        default="turtle",
+    )
+    parser.add_argument(
+        "-t",
+        "--template",
+        help=(
+            "An optionally-provided xlsx-template file to be used in "
+            "SKOS -> xlsx conversion."
+        ),
+        type=Path,
+        metavar=("FILE"),
+    )
+    parser.add_argument(
+        "VOCAB",
+        nargs=1,
+        type=Path,
+        help="Either the file to process or a directory with files to process.",
+    )
+    parser.set_defaults(func=convert)
+
+
+def add_check_subparser(subparsers, options):
+    """Validation and checks of xlsx files, SKOS file and directory usage in CI."""
+
+    parser = subparsers.add_parser(
+        "check",
+        description=(
+            "Perform checks of vocabulary files in xlsx or in SKOS/turtle format."
+            "You can also validate the state of directories in a CI vocabulary pipeline."
+        ),
+        help="Check vocabularies or validate vocabulary pipelines.",
+        **options,
+    )
+    parser.add_argument(
+        "--ci",
+        nargs=1,
+        metavar=("EXISTING",),
+        type=Path,
+        help="Perform checks on EXISTING and VOCAB directories in CI pipeline.",
+    )
+    parser.add_argument(
+        "-p",
+        "--profile",
+        help=(
+            "A token for a SHACL profile to check against. To list the supported "
+            "profiles and their corresponding tokens run the program with the "
+            'flag --listprofiles. (default: "vocpub")'
+        ),
+        default="vocpub",
+    )
+    parser.add_argument(
+        "--fail_at_level",
+        help=(
+            "The minimum level which fails SHACL validation: 1-info, 2-warning, 3-violation "
+            "(default: 1-info)"
+        ),
+        default=1,
+        type=int,
+        choices=[1, 2, 3],
+    )
+    parser.add_argument(
+        "--listprofiles",
+        help=(
+            "List all vocabulary profiles that this converter supports "
+            "indicating both their URI and the short token to use with the "
+            "-p (--profile) flag."
+        ),
+        action="store_true",
+    )
+    parser.add_argument(
+        "VOCAB",
+        nargs="?",
+        type=Path,
+        help="Either the file to process or a directory with files to process.",
+    )
+    parser.set_defaults(func=check)
+
+
+def add_docs_subparser(subparsers, options):
+    """HTML documentation generation for SKOS vocabulary from rdf-format."""
+    parser = subparsers.add_parser(
+        "docs",
+        description="Generate HTML documentation.",
+        help="Generate HTML documentation.",
+        **options,
+    )
+    parser.add_argument(
+        "-O",
+        "--outdir",
+        help=(
+            "Specify directory where files should be written to. "
+            "The directory is created if required."
+        ),
+        metavar=("DIRECTORY"),
+        type=Path,
+    )
+    parser.add_argument(
+        "--style",
+        help="Select style of html documentation. (default: pylode)",
+        choices=("pylode", "ontospy"),
+        type=str,
+        required=False,
+    )
+    parser.add_argument(
+        "VOCAB",
+        nargs=1,
+        type=Path,
+        help="Either the file to process or a directory with files to process.",
+    )
+    parser.set_defaults(func=docs)
+
+
+def main_cli(args=None):
+    """Setup CLI app and run commands based on args."""
+
+    # Create root parser for cli app
+    parser = create_root_parser()
+
+    subparsers = parser.add_subparsers(
+        title="Subcommands",
+        dest="subcommand",
+        description="Get help for commands with voc4cat-ng COMMAND --help",
+        # help="The following sub-commands are available:",
+    )
+    # Create parser to share some options between subparsers. We cannot use the
+    # root parser for this because it includes the sub-commands and their help.
+    common_options_parser = create_common_options_parser()
+
+    # Create the subparsers with some common options
+    common_options = {
+        "parents": [common_options_parser],
+        "formatter_class": DecentFormatter,
+    }
+    add_transform_subparser(subparsers, common_options)
+    add_convert_subparser(subparsers, common_options)
+    add_check_subparser(subparsers, common_options)
+    add_docs_subparser(subparsers, common_options)
+
+    if not args:
+        parser.print_help()
+
+    # Parse the command-line arguments
+    #   pars_args will call sys.exit(2) if invalid commands are given.
+    #   For Py>=3.9 this can be changed https://docs.python.org/3/library/argparse.html#exit-on-error
+    args = parser.parse_args()
+    args.func(args)
+
+
+def run_cli_app(args=None):
+    """Entry point for running the cli app."""
+    if args is None:
         args = sys.argv[1:]
+
+    setup_logging()
+
     try:
         main_cli(args)
     except Voc4catError:
-        logger.exception()
+        logger.exception("Terminating with Voc4cat error.")
         sys.exit(1)
     except Exception:
-        logger.exception()
-        sys.exit(2)
+        logger.exception("Unexpected error.")
+        sys.exit(3)  # value 2 is used by argparse for invalid args.
+
 
 if __name__ == "__main__":
-    start_cli_app(sys.argv[1:])
+    run_cli_app(sys.argv[1:])

--- a/src/voc4cat/cli.py
+++ b/src/voc4cat/cli.py
@@ -1,0 +1,77 @@
+"""New command line interface for voc4cat with subcommands"""
+
+import argparse
+import logging
+import sys
+
+from voc4cat.checks import Voc4catError
+
+logger = logging.getLogger(__name__)
+
+
+def main_cli(args=None):
+    """
+    _summary_
+
+    _extended_summary_
+
+    Parameters
+    ----------
+    args : _type_, optional
+        _description_, by default None
+
+    Possible command structure:
+
+    voc4cat
+    <subcommands>
+    -V --version
+    -H --help
+    -v -vv --verbose
+    -q -qq  --quiet
+    -l --logfile
+    --force (was: --no-warn)        here or better on subcmds?
+    -O --outputdir   here or better on subcmds?
+
+    transform                     Conversions with xlsx files as input and output
+        file-to-process
+        --make-ids prefix start-ID  Specify prefix to search and replace by ID-based vocabulary IRIs. ...
+        --hierarchy-from-indent     Convert concept sheet with indentation to children-URI hierarchy.
+        --hierarchy-to-indent       Convert concept sheet from children-URI hierarchy to indentation.
+        --indent-separator          Separator character(s) to read/write indented hierarchies (default: xlsx indent)
+
+    convert     Convert between rdf and xlsx and back.
+        file-to-process
+        --rdf-format  xml, turtle, json-ld   Output format of generated rdf.
+        --output-type screen/file       Where to output generated rdf.
+        --template  Path to xlsx template to be used when converting to xlsx.
+
+    docs        Documentation generation from rdf
+        file-to-process
+
+    check       Validation and checks
+        file-to-process
+        --xlsx
+        --ci
+        --shacl
+        --listprofiles
+        -p --profile    Profile name or file (implies --shacl = True)
+
+    """
+    parser = argparse.ArgumentParser(
+        prog="voc4cat-ng", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+def start_cli_app(args=None):
+    if args is None:  # app started via entrypoint
+        args = sys.argv[1:]
+    try:
+        main_cli(args)
+    except Voc4catError:
+        logger.exception()
+        sys.exit(1)
+    except Exception:
+        logger.exception()
+        sys.exit(2)
+
+if __name__ == "__main__":
+    start_cli_app(sys.argv[1:])

--- a/src/voc4cat/docs.py
+++ b/src/voc4cat/docs.py
@@ -1,0 +1,36 @@
+import logging
+from pathlib import Path
+
+from voc4cat.wrapper import run_ontospy, run_pylode
+
+logger = logging.getLogger(__name__)
+
+
+def docs(args):
+    logger.info("Docs subcommand started!")
+
+    files = [args.VOCAB] if args.VOCAB.is_file() else [*Path(args.VOCAB).iterdir()]
+    turtle_files = [f for f in files if f.suffix.lower() in (".turtle", ".ttl")]
+
+    if not turtle_files:
+        logger.info("-> Nothing to do. No turtle file(s) found.")
+        return
+
+    for file in turtle_files:
+        logger.debug('Processing "%s"', file)
+        outdir = args.outdir
+        if any(outdir.iterdir()) and not args.force:
+            logger.warning(
+                'The folder "%s" is not empty. Use "--force" to write to the folder anyway.',
+                outdir,
+            )
+            return
+
+        if args.style == "pylode":
+            run_pylode(file, outdir)
+        elif args.style == "ontospy":
+            run_ontospy(file, outdir)
+        else:  # pragma: no cover
+            # This should not be reached since argparse checks --style choices.
+            msg = f"Unsupported style: {args.style}"
+            raise AssertionError(msg)

--- a/src/voc4cat/models.py
+++ b/src/voc4cat/models.py
@@ -164,14 +164,14 @@ class ConceptScheme(BaseModel):
 
     @validator("creator")
     def creator_must_be_from_list(cls, v):
-        if v not in ORGANISATIONS.keys():
+        if v not in ORGANISATIONS:
             msg = f"Organisations must be selected from the Organisations list: {', '.join(ORGANISATIONS)}"
             raise ValueError(msg)
         return v
 
     @validator("publisher")
     def publisher_must_be_from_list(cls, v):
-        if v not in ORGANISATIONS.keys():
+        if v not in ORGANISATIONS:
             msg = f"Organisations must be selected from the Organisations list: {', '.join(ORGANISATIONS)}"
             raise ValueError(msg)
         return v
@@ -195,7 +195,10 @@ class ConceptScheme(BaseModel):
                     v,
                     DCTERMS.modified,
                     Literal(
-                        datetime.datetime.now().strftime("%Y-%m-%d"), datatype=XSD.date
+                        datetime.datetime.now(datetime.timezone.utc).strftime(
+                            "%Y-%m-%d"
+                        ),
+                        datatype=XSD.date,
                     ),
                 )
             )

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -1,0 +1,87 @@
+import logging
+from pathlib import Path
+
+from voc4cat.checks import Voc4catError
+from voc4cat.utils import EXCEL_FILE_ENDINGS, RDF_FILE_ENDINGS
+from voc4cat.wrapper import hierarchy_from_indent, hierarchy_to_indent, make_ids
+
+logger = logging.getLogger(__name__)
+
+
+def _check_make_ids_args(args):
+    """Validate make_ids arguments"""
+    try:
+        start_id = int(args.make_ids[1])
+        msg = "" if start_id > 0 else "Start ID must be greater than zero."
+    except ValueError:
+        msg = "Start ID must be an integer number."
+    if msg:
+        logger.error(msg)
+        raise Voc4catError(msg)
+    if ":" in args.make_ids[0]:
+        prefix, base_iri = args.make_ids[0].split(":", 1)
+        if not base_iri.strip().startswith("http"):
+            msg = 'The base_iri must be in IRI-form and start with "http".'
+            logging.error(msg)
+            raise Voc4catError(msg)
+        base_iri = base_iri.strip()
+    else:
+        prefix, base_iri = args.make_ids[0], None
+    return prefix.strip(), base_iri, start_id
+
+
+def _check_indent(args):
+    if args.indent is None or args.indent.lower() == "xlsx":
+        # xlsx's default indent / openpyxl.styles.Alignment(indent=0)
+        separator = None
+    elif not len(args.indent):
+        msg = "Setting the indent separator to zero length is not allowed."
+        logging.error(msg)
+        raise Voc4catError(msg)
+    else:
+        separator = args.indent
+    return separator
+
+
+def transform(args):
+    logger.info("Transform subcommand started!")
+
+    if args.from_indent or args.to_indent:
+        separator = _check_indent(args)
+
+    if args.make_ids:
+        prefix, base_iri, start_id = _check_make_ids_args(args)
+
+    files = [args.VOCAB] if args.VOCAB.is_file() else [*Path(args.VOCAB).iterdir()]
+    xlsx_files = [f for f in files if f.suffix.lower() in EXCEL_FILE_ENDINGS]
+    rdf_files = [f for f in files if f.suffix.lower() in RDF_FILE_ENDINGS]
+    if args.VOCAB.is_file() and (len(xlsx_files) + len(rdf_files)) == 0:
+        logger.warning("Unsupported filetype: %s", args.VOCAB)
+
+    # transform xlsx files (could be a separate function)
+    for file in xlsx_files:
+        logger.debug('Processing "%s"', file)
+        outfile = file if args.outdir is None else args.outdir / file.name
+        any_action = any(
+            (args.from_indent, args.to_indent, args.make_ids),
+        )
+        if outfile == file and not args.inplace and any_action:
+            logger.warning(
+                'This command will overwrite the existing file "%s".'
+                'Use the flag "--inplace" to enforce replacement or '
+                'supply an output directory with flag "--outdir".',
+                file,
+            )
+            return
+        if args.from_indent:
+            hierarchy_from_indent(file, outfile, separator)
+        elif args.to_indent:
+            hierarchy_to_indent(file, outfile, separator)
+        elif args.make_ids:
+            make_ids(file, outfile, prefix, start_id, base_iri)
+        else:
+            logger.debug("-> nothing to do for xlsx files!")
+
+    for file in rdf_files:
+        logger.debug('Processing "%s"', file)
+        logger.debug("-> nothing to do for rdf files!")

--- a/src/voc4cat/utils.py
+++ b/src/voc4cat/utils.py
@@ -1,12 +1,16 @@
+import glob
 import logging
+import os
 from pathlib import Path
 
 from openpyxl import load_workbook as _load_workbook
 from openpyxl.workbook.workbook import Workbook
 
+from voc4cat.checks import Voc4catError
+
 logger = logging.getLogger(__name__)
 
-EXCEL_FILE_ENDINGS = ["xlsx"]
+EXCEL_FILE_ENDINGS = [".xlsx"]
 RDF_FILE_ENDINGS = {
     ".ttl": "ttl",
     ".rdf": "xml",
@@ -48,12 +52,11 @@ def get_template_version(wb: Workbook) -> str:
         intro_sheet = wb["Introduction"]
         if intro_sheet["J11"].value in KNOWN_TEMPLATE_VERSIONS:
             return intro_sheet["J11"].value
-    except Exception:
-        pass
-
-    # if we get here, the template version is either unknown or can't be located
-    msg = "The version of the Excel template you are using cannot be determined"
-    raise Exception(msg)
+    except Exception as exc:
+        # if we get here, the template version is either unknown or can't be located
+        msg = "The version of the Excel template cannot be determined."
+        logger.exception(msg)
+        raise Voc4catError(msg) from exc
 
 
 def split_and_tidy(cell_value: str):
@@ -63,3 +66,17 @@ def split_and_tidy(cell_value: str):
         return []
     entries = [x.strip() for x in cell_value.strip().split(",")]
     return [x for x in entries if x]
+
+
+def has_file_in_multiple_formats(dir_):
+    files = [
+        os.path.normcase(f)
+        for f in glob.glob(os.path.join(dir_, "*.*"))
+        if f.endswith(tuple(KNOWN_FILE_ENDINGS))
+    ]
+    file_names = [os.path.splitext(f)[0] for f in files]
+    unique_file_names = set(file_names)
+    if len(file_names) == len(unique_file_names):
+        return False
+    seen = set()
+    return [x for x in file_names if x in seen or seen.add(x)]

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,122 @@
+import logging
+import shutil
+
+import pytest
+from test_wrapper import (
+    CS_CYCLES,
+    CS_CYCLES_INDENT_IRI,
+    CS_SIMPLE,
+    CS_SIMPLE_TURTLE,
+)
+from voc4cat.checks import Voc4catError
+from voc4cat.cli import main_cli
+
+
+@pytest.mark.parametrize(
+    ("test_file", "msg"),
+    [
+        (CS_CYCLES, "Extended xlsx checks passed successfully."),
+        (
+            CS_CYCLES_INDENT_IRI,
+            'Same Concept IRI "ex:test/term1" used more than once for language "en"',
+        ),
+    ],
+    ids=["no error", "with error"],
+)
+def test_check_xlsx(datadir, tmp_path, caplog, test_file, msg):
+    dst = tmp_path / test_file
+    shutil.copy(datadir / test_file, dst)
+    with caplog.at_level(logging.INFO):
+        main_cli(["check", "--inplace", str(dst)])
+    assert msg in caplog.text
+    # TODO check that erroneous cells get colored.
+
+
+def test_check_skos_rdf(datadir, tmp_path, caplog):
+    shutil.copy(datadir / CS_SIMPLE_TURTLE, tmp_path)
+    with caplog.at_level(logging.INFO):
+        main_cli(["check", str(tmp_path / CS_SIMPLE_TURTLE)])
+    assert "The file is valid according to the vocpub profile." in caplog.text
+
+
+def test_check_list_profiles(capsys):
+    main_cli(["check", "--listprofiles"])
+    captured = capsys.readouterr()
+    assert "Profiles" in captured.out
+
+
+def test_check_overwrite_warning(monkeypatch, datadir, tmp_path, caplog):
+    shutil.copy(datadir / CS_SIMPLE, tmp_path / CS_SIMPLE)
+    monkeypatch.chdir(tmp_path)
+    # Try to run a command that would overwrite the input file with the output file
+    # a) dir as input:
+    with caplog.at_level(logging.WARNING):
+        main_cli(["check", str(tmp_path)])
+    assert "This command will overwrite the existing file" in caplog.text
+    # b) file as input
+    with caplog.at_level(logging.WARNING):
+        main_cli(["check", str(tmp_path / CS_SIMPLE)])
+
+
+def test_check_ci_pre(datadir, tmp_path, temp_config, caplog):
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    vocabdir = tmp_path / "vocabularies"
+    vocabdir.mkdir(parents=True, exist_ok=True)
+    # Copy test files
+    shutil.copy(datadir / CS_SIMPLE, inbox / "myvocab.xlsx")
+    shutil.copy(datadir / "valid_idranges.toml", tmp_path / "idranges.toml")
+    # Load/prepare a valid strict config
+    config = temp_config
+    config.load_config(tmp_path / "idranges.toml")
+    config.IDRANGES.vocabs["myvocab"].id_length = 2
+    config.IDRANGES.vocabs["myvocab"].permanent_iri_part = "http://example.org/test"
+    config.load_config(config=config.IDRANGES)
+    # Convert vocabulary to ttl and store in vocabdir
+    main_cli(["convert", "-v", "--outdir", str(vocabdir), str(inbox)])
+
+    # Test with one xlsx file in inbox
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["check", "-v", "--ci-pre", str(inbox), str(vocabdir)])
+    assert "Found 1 xlsx file" in caplog.text
+
+
+def test_check_ci_post(datadir, tmp_path, temp_config, caplog):
+    previous = tmp_path / "previous"
+    previous.mkdir()
+    vocabdir = tmp_path / "vocabularies"
+    vocabdir.mkdir(parents=True, exist_ok=True)
+    # Copy test files
+    shutil.copy(datadir / CS_SIMPLE, previous / "myvocab.xlsx")
+    shutil.copy(datadir / "valid_idranges.toml", tmp_path / "idranges.toml")
+    # Load/prepare a valid strict config
+    config = temp_config
+    config.load_config(tmp_path / "idranges.toml")
+    config.IDRANGES.vocabs["myvocab"].id_length = 2
+    config.IDRANGES.vocabs["myvocab"].permanent_iri_part = "http://example.org/test"
+    config.load_config(config=config.IDRANGES)
+    # Convert vocabulary to ttl and store in vocabdir
+    main_cli(["convert", "-v", "--outdir", str(vocabdir), str(previous)])
+
+    # Test without a previous vocabulary version in previous-dir
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["check", "-v", "--ci-post", str(previous), str(vocabdir)])
+    assert 'previous version of vocabulary "myvocab.ttl" does not exist.' in caplog.text
+
+    shutil.copy(vocabdir / "myvocab.ttl", previous)
+    # Test with a previous vocabulary version in previous-dir
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["check", "-v", "--ci-post", str(previous), str(vocabdir)])
+    assert "No removals detected." in caplog.text
+
+
+def test_check_ci_pre_one_folder(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["check", "-v", "--ci-pre", str(tmp_path)])
+    assert "Need two dirs for ci_pre!" in caplog.text
+
+
+def test_check_ci_post_one_folder(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["check", "-v", "--ci-post", str(tmp_path)])
+    assert "Need two dirs for ci_post!" in caplog.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,97 @@
+import logging
+import shutil
+
+import pytest
+from test_wrapper import CS_SIMPLE
+from voc4cat.checks import Voc4catError
+from voc4cat.cli import main_cli, run_cli_app
+
+
+def test_run_cli_app_no_args_entrypoint(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["voc4cat-ng"])
+    run_cli_app()
+    captured = capsys.readouterr()
+    assert "usage: voc4cat-ng" in captured.out
+
+
+def test_run_cli_app_no_args(capsys):
+    run_cli_app([])
+    captured = capsys.readouterr()
+    assert "usage: voc4cat-ng" in captured.out
+
+
+def test_main_unknown_arg(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main_cli(["--unknown-arg"])
+    assert exc_info.value.code == 2  # noqa: PLR2004
+    captured = capsys.readouterr()
+    assert "voc4cat-ng: error: unrecognized arguments: --unknown-arg" in captured.err
+
+
+def test_main_version(capsys):
+    main_cli(["--version"])
+    captured = capsys.readouterr()
+    assert captured.out.startswith("voc4cat")
+
+
+def test_main_subcmd_help(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli_app(["transform", "--help"])
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "usage: voc4cat-ng transform" in captured.out
+
+
+# ===== Tests for common options of all subcommands =====
+
+
+def test_unsupported_filetype(monkeypatch, datadir, caplog):
+    monkeypatch.chdir(datadir)
+    with caplog.at_level(logging.WARNING):
+        main_cli(["transform", "README.md"])
+    assert "Unsupported filetype:" in caplog.text
+
+
+def test_nonexisting_file(monkeypatch, datadir, caplog):
+    monkeypatch.chdir(datadir)
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["transform", "missing.xyz"])
+    assert "File/dir not found: missing.xyz" in caplog.text
+
+
+def test_nonexisting_config(monkeypatch, datadir, caplog):
+    monkeypatch.chdir(datadir)
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["transform", "--config", "missing.toml", CS_SIMPLE])
+    assert "Config file not found at" in caplog.text
+
+
+def test_valid_config(monkeypatch, datadir, caplog, temp_config):
+    # Don't remove "temp_config". The fixture avoid global config change.
+    monkeypatch.chdir(datadir)
+    with caplog.at_level(logging.DEBUG):
+        main_cli(
+            ["transform", "--config", str(datadir / "valid_idranges.toml"), CS_SIMPLE]
+        )
+    assert "Config loaded from" in caplog.text
+
+
+def test_invalid_outdir(monkeypatch, datadir, tmp_path, caplog):
+    monkeypatch.chdir(datadir)
+    shutil.copy(datadir / "README.md", tmp_path)
+    with caplog.at_level(logging.ERROR), pytest.raises(
+        Voc4catError, match="Outdir must be a directory but it is a file."
+    ):
+        main_cli(["transform", "--outdir", str(tmp_path / "README.md"), CS_SIMPLE])
+    assert "Outdir must be a directory but it is a file." in caplog.text
+
+
+# TODO test logs/loglevel
+# @mock.patch.dict(os.environ, {"LOGLEVEL": "DEBUG"})
+# def test_set_log_level_by_envvar(datadir, tmp_path):
+#     dst = tmp_path
+#     shutil.copy(datadir / CS_SIMPLE, dst)
+#     outdir = tmp_path / "out"
+
+#     main_cli(["check", "--ci-pre", "--outdir", str(outdir), str(dst)])
+#     assert ret_code is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,10 +29,9 @@ def test_import(datadir, caplog, temp_config):
     assert len(config.IDRANGES.vocabs["myvocab"].id_range) == 3  # noqa: PLR2004
 
 
-def test_non_exisiting_config_file(tmp_path, caplog):
+def test_non_exisiting_config_file(tmp_path, caplog, temp_config):
     """Test for non-existing path to config which initializes defaults"""
-    from voc4cat import config
-
+    config = temp_config
     fpath = tmp_path / "does-not-exist.toml"
     with caplog.at_level(logging.WARNING):
         config.load_config(config_file=fpath)
@@ -43,9 +42,9 @@ def test_non_exisiting_config_file(tmp_path, caplog):
     assert config.IDRANGES.default_config is True
 
 
-def test_overlapping_idranges(datadir):
+def test_overlapping_idranges(datadir, temp_config):
     """Test for non-existing path to config which initializes defaults"""
-    from voc4cat import config
+    config = temp_config
 
     # load a valid config
     config.load_config(datadir / VALID_CONFIG)
@@ -59,9 +58,9 @@ def test_overlapping_idranges(datadir):
         config.load_config(config=config.IDRANGES)
 
 
-def test_single_vocab_consistency(datadir):
+def test_single_vocab_consistency(datadir, temp_config):
     """Test consistency check for single_vocab=True."""
-    from voc4cat import config
+    config = temp_config
 
     # load a valid config
     config.load_config(datadir / VALID_CONFIG)
@@ -82,9 +81,9 @@ def test_single_vocab_consistency(datadir):
         config.load_config(config=config.IDRANGES)
 
 
-def test_idrange_item_validation(datadir):
+def test_idrange_item_validation(datadir, temp_config):
     """Test for custom vlidators in config.IdrangeItem"""
-    from voc4cat import config
+    config = temp_config
 
     with pytest.raises(ValidationError) as excinfo:
         _bad_ids = config.IdrangeItem(first_id=2, last_id=2, gh_name="no-range")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,106 @@
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+import voc4cat
+from test_wrapper import (
+    CS_CYCLES,
+    CS_CYCLES_INDENT,
+    CS_CYCLES_TURTLE,
+    CS_SIMPLE,
+)
+from voc4cat.checks import Voc4catError
+from voc4cat.cli import main_cli
+from voc4cat.utils import ConversionError
+
+
+def test_run_vocexcel_badfile(monkeypatch, datadir, tmp_path, caplog):
+    """Check handling of failing run of vocexcel."""
+    shutil.copy(datadir / CS_CYCLES_INDENT, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.ERROR), pytest.raises(ConversionError):
+        main_cli(["convert", CS_CYCLES_INDENT])
+    # The next message is logged by vocexcel so it may change.
+    assert "VIOLATION: Validation Result in MinCountConstraintComponent" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [CS_SIMPLE, ""],
+    ids=["single file", "dir of files"],
+)
+def test_run_vocexcel(datadir, tmp_path, test_file):
+    """Check that an xlsx file is converted to ttl by vocexcel."""
+    dst = tmp_path / test_file
+    shutil.copy(datadir / CS_SIMPLE, dst)
+    # We also test if the logging option works.
+    log = tmp_path / "logs" / "test-run.log"
+    main_cli(["convert", "-v", "--logfile", str(log), str(dst)])
+    expected = (tmp_path / CS_SIMPLE).with_suffix(".ttl")
+    assert expected.exists()
+    assert log.exists()
+
+
+@pytest.mark.parametrize(
+    ("outputdir", "testfile"),
+    [
+        ("out", CS_CYCLES),
+        ("", CS_CYCLES),
+        ("out", CS_CYCLES_TURTLE),
+        ("", CS_CYCLES_TURTLE),
+    ],
+    ids=["out:dir & xlsx", "out:default & xlsx", "out:dir & ttl", "out:default & ttl"],
+)
+def test_run_vocexcel_outputdir(monkeypatch, datadir, tmp_path, outputdir, testfile):
+    """Check that an xlsx file is converted to ttl by vocexcel."""
+    shutil.copy(datadir / testfile, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # Check if log is placed in out folder.
+    log = "test-run.log"
+    main_cli(
+        ["convert", "--logfile", str(log)]
+        + (["--outdir", str(outputdir)] if outputdir else [])
+        + [str(tmp_path)]
+    )
+    outdir = tmp_path / outputdir
+    if testfile.endswith("xlsx"):
+        assert (outdir / testfile).with_suffix(".ttl").exists()
+    else:
+        assert (outdir / testfile).with_suffix(".xlsx").exists()
+    assert (outdir / log).exists()
+
+
+def test_duplicates(datadir, tmp_path, caplog):
+    """Check that files do not have the same stem."""
+    shutil.copy(datadir / CS_CYCLES, tmp_path)
+    shutil.copy(datadir / CS_CYCLES_TURTLE, tmp_path)
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["convert", str(tmp_path)])
+    assert "Files may only be present in one format." in caplog.text
+
+
+def test_template(monkeypatch, datadir, tmp_path, caplog):
+    """Check template option."""
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(datadir / CS_CYCLES_TURTLE, tmp_path)
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["convert", "--template", "missing.xlsx", str(tmp_path)])
+    assert "Template file not found: " in caplog.text
+
+    caplog.clear()
+    Path(tmp_path / "template.txt").touch()
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["convert", "--template", "template.txt", str(tmp_path)])
+    assert 'Template file must be of type ".xlsx".' in caplog.text
+
+    caplog.clear()
+    std_template = str(Path(voc4cat.__file__).parent / "blank_043.xlsx")
+    with caplog.at_level(logging.INFO):
+        main_cli(["convert", "-v", "--template", std_template, str(tmp_path)])
+    assert "->" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["convert", "-v", str(tmp_path / "template.txt")])
+    assert "-> nothing to do for this file type!" in caplog.text

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,69 @@
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+from test_wrapper import (
+    CS_CYCLES_TURTLE,
+)
+from voc4cat.checks import Voc4catError
+from voc4cat.cli import main_cli
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [CS_CYCLES_TURTLE, ""],
+    ids=["single file", "dir of files"],
+)
+def test_build_docs_ontospy(datadir, tmp_path, test_file):
+    """Check that ontospy generates the expected output."""
+    dst = tmp_path / test_file
+    shutil.copy(datadir / CS_CYCLES_TURTLE, tmp_path)
+    outdir = tmp_path / "ontospy"
+    # To test the code-path, outdir is created automatically here.
+    main_cli(["docs", "--style", "ontospy", "--outdir", str(outdir), str(dst)])
+    assert (outdir / Path(CS_CYCLES_TURTLE).stem / "dendro" / "index.html").exists()
+    assert (outdir / Path(CS_CYCLES_TURTLE).stem / "docs" / "index.html").exists()
+
+
+def test_build_docs_pylode(datadir, tmp_path):
+    """Check that pylode generates the expected output."""
+    dst = tmp_path
+    shutil.copy(datadir / CS_CYCLES_TURTLE, tmp_path)
+    outdir = tmp_path / "pylode"
+    # To test the code-path, outdir is created automatically here.
+    main_cli(["docs", "--style", "pylode", "--outdir", str(outdir), str(dst)])
+    assert (outdir / Path(CS_CYCLES_TURTLE).stem / "index.html").exists()
+
+
+def test_build_docs(datadir, tmp_path, caplog):
+    """Check overwrite warning and output folder creation."""
+    dst = tmp_path
+    outdir = tmp_path / "new"
+
+    # existing non-empty output folder
+    outdir.mkdir()
+    shutil.copy(datadir / CS_CYCLES_TURTLE, outdir)
+    shutil.copy(datadir / CS_CYCLES_TURTLE, dst)
+    with caplog.at_level(logging.WARNING):
+        main_cli(["docs", "--style", "pylode", "--outdir", str(outdir), str(dst)])
+    assert (
+        f'The folder "{outdir}" is not empty. Use "--force" to write to the folder anyway.'
+        in caplog.text
+    )
+    # force use of existing non-empty output folder
+    main_cli(
+        ["docs", "--style", "pylode", "--force", "--outdir", str(outdir), str(dst)]
+    )
+    assert (outdir / Path(CS_CYCLES_TURTLE).stem / "index.html").exists()
+
+
+def test_build_docs_no_input(tmp_path, caplog):
+    """Check handling of of missing file or empty dir in documentation build."""
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["docs", "--outdir", str(tmp_path), str(tmp_path / CS_CYCLES_TURTLE)])
+    assert f"File/dir not found: {tmp_path/CS_CYCLES_TURTLE}" in caplog.text
+
+    with caplog.at_level(logging.INFO):
+        main_cli(["docs", "--outdir", str(tmp_path), str(tmp_path)])
+    assert "Nothing to do. No turtle file" in caplog.text

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,527 @@
+import logging
+import shutil
+
+import pytest
+from openpyxl import load_workbook
+from test_wrapper import (
+    CS_CYCLES,
+    CS_CYCLES_INDENT_DOT,
+    CS_CYCLES_INDENT_IRI,
+    CS_CYCLES_MULTI_LANG,
+    CS_CYCLES_MULTI_LANG_IND,
+    CS_SIMPLE,
+    CS_SIMPLE_TURTLE,
+)
+from voc4cat.checks import Voc4catError
+from voc4cat.cli import main_cli
+
+# ===== Tests for no option set =====
+
+
+def test_transform_no_option(monkeypatch, datadir, tmp_path, caplog):
+    shutil.copy(datadir / CS_SIMPLE, tmp_path / CS_SIMPLE)
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["transform", str(tmp_path)])
+    assert "nothing to do for xlsx files" in caplog.text
+
+    shutil.copy(datadir / CS_SIMPLE_TURTLE, tmp_path / CS_SIMPLE_TURTLE)
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["transform", str(tmp_path)])
+    assert "nothing to do for rdf files" in caplog.text
+
+
+def test_transform_unsupported_filetype(monkeypatch, datadir, tmp_path, caplog):
+    shutil.copy(datadir / "README.md", tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # Try to run a command that would overwrite the input file with the output file
+    with caplog.at_level(logging.WARNING):
+        main_cli(["transform", str(tmp_path / "README.md")])
+    assert "Unsupported filetype: " in caplog.text
+
+
+# ===== Tests for option --make-ids =====
+
+
+def test_make_ids_missing_file(caplog):
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["transform", "--make-ids", "ex", "1", "missing.xyz"])
+    assert "File/dir not found: missing.xyz" in caplog.text
+
+
+def test_make_ids_overwrite_warning(monkeypatch, datadir, tmp_path, caplog):
+    shutil.copy(datadir / CS_SIMPLE, tmp_path / CS_SIMPLE)
+    monkeypatch.chdir(tmp_path)
+    # Try to run a command that would overwrite the input file with the output file
+    # a) dir as input:
+    with caplog.at_level(logging.WARNING):
+        main_cli(["transform", "--make-ids", "ex", "1", str(tmp_path)])
+    assert "This command will overwrite the existing file" in caplog.text
+    # b) file as input
+    with caplog.at_level(logging.WARNING):
+        main_cli(["transform", "--make-ids", "ex", "1", str(tmp_path / CS_SIMPLE)])
+    assert "This command will overwrite the existing file" in caplog.text
+
+
+def test_make_ids_no_voc_base_iri(monkeypatch, datadir, tmp_path):
+    shutil.copy(datadir / CS_SIMPLE, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # change excel file: Delete vocabulary base IRI
+    wb = load_workbook(filename=CS_SIMPLE)
+    ws = wb["Concept Scheme"]
+    ws.cell(row=2, column=2).value = None
+    new_filename = "no_voc_base_iri.xlsx"
+    wb.save(new_filename)
+    wb.close()
+
+    main_cli(
+        [
+            "transform",
+            "--make-ids",
+            "na",
+            "1001",
+            "--inplace",
+            str(tmp_path / new_filename),
+        ]
+    )
+    wb = load_workbook(filename=new_filename, read_only=True, data_only=True)
+    ws = wb["Concept Scheme"]
+    assert ws.cell(row=2, column=2).value == "https://example.org/"
+
+
+def test_make_ids_invalid_id(datadir):
+    with pytest.raises(
+        Voc4catError,
+        match="Start ID must be an integer number.",
+    ):
+        main_cli(
+            [
+                "transform",
+                "--make-ids",
+                "ex",
+                "###",
+                "--inplace",
+                str(datadir / CS_SIMPLE),
+            ]
+        )
+
+
+def test_make_ids_invalid_base_iri(datadir):
+    with pytest.raises(
+        Voc4catError,
+        match='The base_iri must be in IRI-form and start with "http".',
+    ):
+        main_cli(
+            [
+                "transform",
+                "--make-ids",
+                "ex:ftp://example.org",
+                "1",
+                "--inplace",
+                str(datadir / CS_SIMPLE),
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("indir", "outdir"),
+    [(True, ""), (True, "out"), (False, ""), (False, "out")],
+    ids=[
+        "in:dir, out:default",
+        "in:dir, out:dir",
+        "in:file, out:default",
+        "in:file, out:dir",
+    ],
+)
+def test_make_ids_variants(monkeypatch, datadir, tmp_path, indir, outdir):
+    # fmt: off
+    expected_concepts = [
+        ("ex:test/0001001", "term1", "en", "def for term1", "en", "AltLbl for term1", "ex:test/0001002, ex:test/0001003",),
+        ("ex:test/0001002", "term2", "en", "def for term2", "en", "AltLbl for term2", None,),
+        ("ex:test/0001003", "term3", "en", "def for term3", "en", "AltLbl for term3", "ex:test/0001004",),
+        ("ex:test/0001004", "term4", "en", "def for term4", "en", "AltLbl for term4", None, ),
+        ("ex:test/0001005", "term5", "en", "def for term5", "en", "AltLbl for term5", None, ),
+        ("ex:test/0001006", "term6", "en", "def for term6", "en", "AltLbl for term6", None,),
+    ]
+    expected_collections = [
+        ("ex:test/0001007", "con", "def for con", "ex:test/0001001, ex:test/0001002, ex:test/0001003, ex:test/0001004",),
+    ]
+    expected_additional = [
+        ("ex:test/0001001", "ex:test/0001002", "ex:test/0001003", "ex:test/0001004", "ex:test/0001005", "ex:test/0001006", ),
+    ]
+    # fmt: on
+    shutil.copy(datadir / CS_SIMPLE, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    main_cli(
+        ["transform", "--make-ids", "ex", "1001", "--inplace"]
+        + (["--outdir", outdir] if outdir else [])
+        + ([str(tmp_path)] if indir else [str(tmp_path / CS_SIMPLE)])
+    )
+    xlsxfile = tmp_path / outdir / CS_SIMPLE if outdir else tmp_path / CS_SIMPLE
+    wb = load_workbook(filename=xlsxfile, read_only=True, data_only=True)
+    ws = wb["Concepts"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=7, values_only=True), expected_concepts
+    ):
+        assert row == expected_row
+    ws = wb["Collections"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=4, values_only=True), expected_collections
+    ):
+        assert row == expected_row
+    ws = wb["Additional Concept Features"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=6, values_only=True), expected_additional
+    ):
+        assert row == expected_row
+
+
+def test_make_ids_base_iri(monkeypatch, datadir, tmp_path):
+    # fmt: off
+    expected_concepts = [
+        ("https://example.com/new_0001001", "term1", "en", "def for term1", "en", "AltLbl for term1", "https://example.com/new_0001002, https://example.com/new_0001003",),
+        ("https://example.com/new_0001002", "term2", "en", "def for term2", "en", "AltLbl for term2", None,),
+        ("https://example.com/new_0001003", "term3", "en", "def for term3", "en", "AltLbl for term3", "https://example.com/new_0001004",),
+        ("https://example.com/new_0001004", "term4", "en", "def for term4", "en", "AltLbl for term4", None, ),
+        ("https://example.com/new_0001005", "term5", "en", "def for term5", "en", "AltLbl for term5", None, ),
+        ("https://example.com/new_0001006", "term6", "en", "def for term6", "en", "AltLbl for term6", None,),
+    ]
+    expected_collections = [
+        ("https://example.com/new_0001007", "con", "def for con", "https://example.com/new_0001001, https://example.com/new_0001002, https://example.com/new_0001003, https://example.com/new_0001004",),
+    ]
+    expected_additional = [
+        ("https://example.com/new_0001001", "https://example.com/new_0001002", "https://example.com/new_0001003", "https://example.com/new_0001004", "https://example.com/new_0001005", "https://example.com/new_0001006", ),
+    ]
+    # fmt: on
+    shutil.copy(datadir / CS_SIMPLE, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    main_cli(
+        [
+            "transform",
+            "--make-ids",
+            "ex:https://example.com/new_",
+            "1001",
+            "--inplace",
+            str(tmp_path / CS_SIMPLE),
+        ]
+    )
+    xlsxfile = tmp_path / CS_SIMPLE
+    wb = load_workbook(filename=xlsxfile, read_only=True, data_only=True)
+    ws = wb["Concepts"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=7, values_only=True), expected_concepts
+    ):
+        assert row == expected_row
+    ws = wb["Collections"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=4, values_only=True), expected_collections
+    ):
+        assert row == expected_row
+    ws = wb["Additional Concept Features"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=6, values_only=True), expected_additional
+    ):
+        assert row == expected_row
+
+
+def test_make_ids_multilang(tmp_path, datadir):
+    # fmt: off
+    expected_concepts = [
+        ("ex:test/0001001", "term1", "en", "def for term1", "en", "AltLbl for term1", "ex:test/0001002, ex:test/0001003",),
+        ("ex:test/0001002", "term2", "en", "def for term2", "en", "AltLbl for term2", "ex:test/0001004",),
+        ("ex:test/0001003", "term3", "en", "def for term3", "en", "AltLbl for term3", "ex:test/0001004",),
+        ("ex:test/0001004", "term4", "en", "def for term4", "en", "AltLbl for term4", None, ),
+        ("ex:test/0001004", "Begr4", "de", "Def für Begr4", "de", "AltLbl für Begr4", None, ),
+        ("ex:test/0001001", "Begr1", "de", "Def für Begr1", "de", "AltLbl für Begr1", None, ),
+    ]
+    # fmt: on
+    main_cli(
+        [
+            "transform",
+            "--make-ids",
+            "ex",
+            "1001",
+            "--outdir",
+            str(tmp_path),
+            str(datadir / CS_CYCLES_MULTI_LANG),
+        ]
+    )
+    xlsxfile = tmp_path / CS_CYCLES_MULTI_LANG
+    wb = load_workbook(filename=xlsxfile, read_only=True, data_only=True)
+    ws = wb["Concepts"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=7, values_only=True), expected_concepts
+    ):
+        assert row == expected_row
+
+
+# ===== Tests for option --from-indent / --to-indent =====
+
+
+@pytest.mark.parametrize(
+    "option",
+    ["--from-indent", "--to-indent"],
+)
+def test_no_separator(monkeypatch, datadir, option):
+    monkeypatch.chdir(datadir)
+    with pytest.raises(
+        Voc4catError,
+        match="Setting the indent separator to zero length is not allowed.",
+    ):
+        main_cli(["transform", option, "--indent", "", CS_CYCLES])
+
+
+# ===== Tests for option --from-indent =====
+
+
+def test_hierarchy_from_indent_on_dir(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["transform", "--from-indent", str(tmp_path / "missing.xlsx")])
+    assert "File/dir not found:" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("xlsxfile", "indent"),
+    [(CS_CYCLES_INDENT_IRI, None), (CS_CYCLES_INDENT_DOT, "..")],
+    ids=["indent:Excel", "indent:dots"],
+)
+def test_hierarchy_from_indent(monkeypatch, datadir, tmp_path, xlsxfile, indent):
+    # fmt: off
+    expected = [  # data in children-IRI-representation
+        ("ex:test/term1", "term1", "en", "def for term1", "en", "AltLbl for term1", "ex:test/term2, ex:test/term3", "Prov for term1", "ex:XYZ/term1"),
+        ("ex:test/term2", "term2", "en", "def for term2", "en", "AltLbl for term2", "ex:test/term4",                "Prov for term2", "ex:XYZ/term2"),
+        ("ex:test/term3", "term3", "en", "def for term3", "en", "AltLbl for term3", "ex:test/term4",                "Prov for term3", "ex:XYZ/term3"),
+        ("ex:test/term4", "term4", "en", "def for term4", "en", "AltLbl for term4", None,                           "Prov for term4", "ex:XYZ/term4"),
+        (None, None, None, None, None, None, None, None, None)
+    ]
+    # fmt: on
+    expected_len = len(expected[0])
+    monkeypatch.chdir(datadir)
+    main_cli(
+        ["transform", "--from-indent"]
+        + (
+            [
+                "--indent",
+                indent,
+            ]
+            if indent
+            else []
+        )
+        + [
+            "--outdir",
+            str(tmp_path),
+            xlsxfile,
+        ]
+    )
+    monkeypatch.chdir(tmp_path)
+    wb = load_workbook(filename=xlsxfile, read_only=True, data_only=True)
+    ws = wb["Concepts"]
+    for row, _expected_row in zip(ws.iter_rows(min_row=3, values_only=True), expected):
+        assert len(row) == expected_len
+        assert row in expected  # We intentionally don't check the row position here!
+
+
+def test_hierarchy_from_indent_multilang(monkeypatch, datadir, tmp_path):
+    # fmt: off
+    expected = [  # data in children-IRI-representation
+        ("ex:test/term1", "term1", "en", "def for term1", "en", "AltLbl for term1", "ex:test/term2, ex:test/term3", "Prov for term1", "ex:XYZ/term1"),
+        ("ex:test/term1", "Begr1", "de", "Def für Begr1", "de", "AltLbl für Begr1", "ex:test/term2, ex:test/term3", "Prov for term1", "ex:XYZ/term1"),
+        ("ex:test/term2", "term2", "en", "def for term2", "en", "AltLbl for term2", "ex:test/term4", "Prov for term2", "ex:XYZ/term2"),
+        ("ex:test/term3", "term3", "en", "def for term3", "en", "AltLbl for term3", "ex:test/term4", "Prov for term3", "ex:XYZ/term3"),
+        ("ex:test/term4", "term4", "en", "def for term4", "en", "AltLbl for term4", None,            "Prov for term4", "ex:XYZ/term4"),
+        ("ex:test/term4", "Begr4", "de", "Def für Begr4", "de", "AltLbl für Begr4", None,            "Prov for term4", "ex:XYZ/term4"),
+        (None, None, None, None, None, None, None, None, None)
+    ]
+    # fmt: on
+    expected_len = len(expected[0])
+    monkeypatch.chdir(datadir)
+    main_cli(
+        [
+            "transform",
+            "--from-indent",
+            "--outdir",
+            str(tmp_path),
+            CS_CYCLES_MULTI_LANG_IND,
+        ]
+    )
+    monkeypatch.chdir(tmp_path)
+    wb = load_workbook(
+        filename=CS_CYCLES_MULTI_LANG_IND, read_only=True, data_only=True
+    )
+    ws = wb["Concepts"]
+    for row, _expected_row in zip(ws.iter_rows(min_row=3, values_only=True), expected):
+        assert len(row) == expected_len
+        assert row in expected  # We intentionally don't check the row position here!
+
+
+def test_hierarchy_from_indent_merge(monkeypatch, datadir, tmp_path):
+    shutil.copy(datadir / CS_CYCLES_INDENT_IRI, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # change excel file: Delete vocabulary base IRI
+    wb = load_workbook(filename=CS_CYCLES_INDENT_IRI)
+    ws = wb["Concepts"]
+    ws.cell(row=8, column=4).value = "Contradicting def."
+    iri = ws.cell(row=8, column=1).value
+    new_filename = "indent_merge_problem.xlsx"
+    wb.save(new_filename)
+    wb.close()
+    with pytest.raises(
+        ValueError, match=f"Cannot merge rows for {iri}. Resolve differences manually."
+    ):
+        main_cli(
+            ["transform", "--from-indent", "--inplace", str(tmp_path / new_filename)]
+        )
+
+
+# ===== Tests for option --to-indent =====
+
+
+@pytest.mark.parametrize(
+    "indent",
+    ["..", None],
+    ids=["indent:dots", "indent:Excel"],
+)
+def test_hierarchy_to_indent(monkeypatch, datadir, tmp_path, indent):
+    # fmt: off
+    expected_rows = [  # data in children-IRI-representation
+        ("ex:test/term1", "term1",     "en", "def for term1", "en", "AltLbl for term1", None, "Prov for term1", "ex:XYZ/term1"),
+        ("ex:test/term3", "..term3",   "en", "def for term3", "en", "AltLbl for term3", None, "Prov for term3", "ex:XYZ/term3"),
+        ("ex:test/term4", "....term4", "en", "def for term4", "en", "AltLbl for term4", None, "Prov for term4", "ex:XYZ/term4"),
+        ("ex:test/term2", "term2",     "en", "def for term2", "en", "AltLbl for term2", None, "Prov for term2", "ex:XYZ/term2"),
+        ("ex:test/term4", "..term4",   "en", None, None, None, None, None, None),
+        ("ex:test/term1", "term1",     "en", None, None, None, None, None, None),
+        ("ex:test/term2", "..term2",   "en", None, None, None, None, None, None),
+        (None, None, None, None, None, None, None, None, None),
+    ]
+    # fmt: on
+    expected_levels = [0, 1, 2, 0, 1, 0, 1, 0]
+    assert len(expected_rows) == len(expected_levels)
+    expected_len = len(expected_rows[0])
+
+    monkeypatch.chdir(datadir)
+    main_cli(
+        ["transform", "--to-indent"]
+        + (
+            [
+                "--indent",
+                indent,
+            ]
+            if indent
+            else []
+        )
+        + [
+            "--outdir",
+            str(tmp_path),
+            CS_CYCLES,
+        ]
+    )
+    monkeypatch.chdir(tmp_path)
+    wb = load_workbook(filename=CS_CYCLES, read_only=True)
+    ws = wb["Concepts"]
+    for row, expected_row, expected_level in zip(
+        ws.iter_rows(min_row=3), expected_rows, expected_levels
+    ):
+        assert len(row) == expected_len
+        if indent is None:  # Excel-indent
+            assert int(row[1].alignment.indent) == expected_level
+
+        for col in range(len(expected_rows)):
+            if indent is None and col == 1:  # Excel-indent
+                continue
+            assert row[col].value == expected_row[col]
+
+
+def test_hierarchy_to_indent_multilanguage(monkeypatch, datadir, tmp_path):
+    # fmt: off
+    expected_rows = [  # data in children-IRI-representation
+        ("ex:test/term1", "term1",     "en", "def for term1", "en", "AltLbl for term1", None, "Prov for term1", "ex:XYZ/term1"),
+        ("ex:test/term1", "Begr1",     "de", "Def für Begr1", "de", "AltLbl für Begr1", None, "Prov for term1", "ex:XYZ/term1"),
+        ("ex:test/term3", "..term3",   "en", "def for term3", "en", "AltLbl for term3", None, "Prov for term3", "ex:XYZ/term3"),
+        ("ex:test/term4", "....term4", "en", "def for term4", "en", "AltLbl for term4", None, "Prov for term4", "ex:XYZ/term4"),
+        ("ex:test/term4", "....Begr4", "de", "Def für Begr4", "de", "AltLbl für Begr4", None, "Prov for term4", "ex:XYZ/term4"),
+        ("ex:test/term2", "term2",     "en", "def for term2", "en", "AltLbl for term2", None, "Prov for term2", "ex:XYZ/term2"),
+        ("ex:test/term4", "..term4",   "en", None, None, None, None, None, None),
+        ("ex:test/term1", "term1",     "en", None, None, None, None, None, None),
+        ("ex:test/term2", "..term2",   "en", None, None, None, None, None, None),
+        (None, None, None, None, None, None, None, None, None),
+    ]
+    # fmt: on
+    expected_levels = [0, 0, 1, 2, 2, 0, 1, 0, 1, 0]
+    assert len(expected_rows) == len(expected_levels)
+    monkeypatch.chdir(datadir)
+    main_cli(
+        [
+            "transform",
+            "--to-indent",
+            "--outdir",
+            str(tmp_path),
+            CS_CYCLES_MULTI_LANG,
+        ]
+    )
+    monkeypatch.chdir(tmp_path)
+    wb = load_workbook(filename=CS_CYCLES_MULTI_LANG, read_only=True)
+    ws = wb["Concepts"]
+    for row, expected_row, expected_level in zip(
+        ws.iter_rows(min_row=3), expected_rows, expected_levels
+    ):
+        # Excel-indent
+        assert int(row[1].alignment.indent) == expected_level
+
+        for col in range(len(expected_rows[0])):
+            if col == 1:  # Excel-indent
+                assert row[col].value == expected_row[col].strip(".")
+                continue
+            assert row[col].value == expected_row[col]
+
+
+def test_hierarchy_to_indent_merge(monkeypatch, datadir, tmp_path):
+    shutil.copy(datadir / CS_CYCLES_MULTI_LANG, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # change excel file: Delete vocabulary base IRI
+    wb = load_workbook(filename=CS_CYCLES_MULTI_LANG)
+    ws = wb["Concepts"]
+    ws.cell(row=8, column=8).value = "Contradicting def."
+    iri = ws.cell(row=8, column=1).value
+    new_filename = "indent_merge_problem.xlsx"
+    wb.save(new_filename)
+    wb.close()
+    with pytest.raises(ValueError, match=f"Merge conflict for concept {iri}"):
+        main_cli(
+            ["transform", "--to-indent", "--inplace", str(tmp_path / new_filename)]
+        )
+
+
+@pytest.mark.parametrize(
+    "outdir",
+    [None, "out"],
+    ids=["no outdir", "with outdir"],
+)
+def test_outdir_variants(monkeypatch, datadir, tmp_path, outdir):
+    shutil.copy(datadir / CS_CYCLES_INDENT_IRI, tmp_path)
+    cmd = ["transform", "--from-indent"]
+    if outdir:
+        cmd.extend(["--outdir", str(tmp_path / outdir)])
+    else:
+        cmd.append("--inplace")
+    cmd.append(str(tmp_path / CS_CYCLES_INDENT_IRI))
+    monkeypatch.chdir(tmp_path)
+    main_cli(cmd)
+
+    expected = [
+        ("ex:test/term1", "term1"),
+        ("ex:test/term3", "term3"),
+        ("ex:test/term4", "term4"),
+        ("ex:test/term2", "term2"),
+        (None, None),
+    ]
+    if outdir:
+        xlsxfile = tmp_path / outdir / CS_CYCLES_INDENT_IRI
+    else:
+        xlsxfile = tmp_path / CS_CYCLES_INDENT_IRI
+    wb = load_workbook(filename=xlsxfile, read_only=True, data_only=True)
+    ws = wb["Concepts"]
+    for row, expected_row in zip(
+        ws.iter_rows(min_row=3, max_col=2, values_only=True), expected
+    ):
+        assert row == expected_row

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -20,7 +20,7 @@ CS_CYCLES_MULTI_LANG_IND = "concept-scheme-with-cycles_multilang_indent_iri.xlsx
 
 
 def test_main_no_args_entrypoint(monkeypatch, capsys):
-    monkeypatch.setattr("sys.argv", ["voc4at"])
+    monkeypatch.setattr("sys.argv", ["voc4cat"])
     exit_code = main_cli()
     captured = capsys.readouterr()
     assert "usage: voc4cat" in captured.out
@@ -49,7 +49,6 @@ def test_main_version(capsys):
 
 
 def test_make_ids_missing_file(caplog):
-    # Try to run a command that would overwrite the input file with the output file
     with caplog.at_level(logging.ERROR):
         exit_code = main_cli(["--make-ids", "ex", "1", "missing.xyz"])
     assert "Expected xlsx-file or directory but got:" in caplog.text
@@ -404,7 +403,6 @@ def test_outdir_variants(monkeypatch, datadir, tmp_path, outdir):
     if outdir:
         cmd.extend(["--output-directory", str(tmp_path / outdir)])
     cmd.append(str(tmp_path / CS_CYCLES_INDENT_IRI))
-    # print(f"\n>>> cmd {cmd}")
     monkeypatch.chdir(tmp_path)
     main_cli(cmd)
 
@@ -627,6 +625,9 @@ def test_no_separator(monkeypatch, datadir):
         ValueError, match="Setting the indent separator to zero length is not allowed."
     ):
         main_cli(["--indent-separator", "", CS_CYCLES])
+
+
+# TODO From here on review rest of tests for new cli.
 
 
 def test_duplicates(datadir, tmp_path, caplog):


### PR DESCRIPTION
The new cli has 4 sub-commands: `transform`, `convert`, `check` and `docs`. In contrast to the current CLI (0.5.0) the new sub-commands do one think at a time. There is no magic of chaining actions like in the current CLI, which made the code too complex and difficult to extend. The new sub-commands share a common set of options, like e.g. `--help`, `--config` or `--logfile`. The new code uses many of [argparse](https://docs.python.org/dev/library/argparse.html)'s features which results in cleaner well-structured code. This will make future changes and additions much easier.

The new CLI can be run via the command `voc4cat-ng` (ng = next generation) until it becomes the default CLI in 0.6.0. The existing CLIs (`voc4cat` / `vocexcel`) remain unchanged in the 0.5.x series and will be removed in 0.6.0.

Still to do:

- [x] Draft structure of new command and its [subcommands](https://docs.python.org/dev/library/argparse.html#sub-commands)
- [x] Implement interface in argparse
- [x] Add test for new interface

Closes #128