### PR TITLE
Improvements for using 0.6.x in gh-actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change log
 
+## Release 0.6.x (2023-08-dd)
+
+New features:
+
+- The `merge_vocab` script gained support for directories containing vocabularies created with `voc4cat transform --split`. This feature is used in gh-actions of [voc4cat-template](https://github.com/nfdi4cat/voc4cat-template)-based vocabularies.
+
+Changes:
+
+- The log file will now always be written to the given directory. Previously the log file directory depended on the presence of the `--outdir` option.
+
+Bug fixes:
+
+- Sub-command `voc4cat docs` failed if `--outdir` was not given.
+
 ## Release 0.6.0 (2023-08-09)
 
 New features:

--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -120,6 +120,7 @@ def check(args):
         inbox_dir, vocab_dir = args.ci_pre, args.VOCAB
         check_number_of_files_in_inbox(inbox_dir)
         validate_vocabulary_files_for_ci_workflow(vocab_dir, inbox_dir)
+        logger.info("-> Check ci-pre passed.")
         return
 
     if args.ci_post:
@@ -135,6 +136,7 @@ def check(args):
                 )
                 continue
             check_for_removed_iris(prev, new)
+            logger.info("-> Check ci-post passed.")
         return
 
     files = [args.VOCAB] if args.VOCAB.is_file() else [*Path(args.VOCAB).iterdir()]

--- a/src/voc4cat/cli.py
+++ b/src/voc4cat/cli.py
@@ -34,9 +34,7 @@ def process_common_options(args):
     if logfile is None:
         setup_logging(loglevel)
     else:
-        if outdir is not None:
-            logfile = Path(outdir) / logfile
-        elif not logfile.parents[0].exists():
+        if not logfile.parents[0].exists():
             logfile.parents[0].mkdir(exist_ok=True, parents=True)
         setup_logging(loglevel, logfile)
 

--- a/src/voc4cat/docs.py
+++ b/src/voc4cat/docs.py
@@ -77,7 +77,7 @@ def docs(args):
 
     for file in turtle_files:
         logger.debug('Processing "%s"', file)
-        outdir = args.outdir
+        outdir = file.parent if args.outdir is None else args.outdir
         if any(outdir.iterdir()) and not args.force:
             logger.warning(
                 'The folder "%s" is not empty. Use "--force" to write to the folder anyway.',

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -45,7 +45,7 @@ def test_run_vocexcel_outputdir(monkeypatch, datadir, tmp_path, outputdir, testf
     shutil.copy(datadir / testfile, tmp_path)
     monkeypatch.chdir(tmp_path)
     # Check if log is placed in out folder.
-    log = "test-run.log"
+    log = Path(outputdir) / "test-run.log"
     main_cli(
         ["convert", "--logfile", str(log)]
         + (["--outdir", str(outputdir)] if outputdir else [])
@@ -56,7 +56,7 @@ def test_run_vocexcel_outputdir(monkeypatch, datadir, tmp_path, outputdir, testf
         assert (outdir / testfile).with_suffix(".ttl").exists()
     else:
         assert (outdir / testfile).with_suffix(".xlsx").exists()
-    assert (outdir / log).exists()
+    assert (outdir / log.name).exists()
 
 
 def test_duplicates(datadir, tmp_path, caplog):


### PR DESCRIPTION
- Fix `voc4cat docs` sub-cmd to work with and without `--outdir`.
- Remove magic for logfile directory selection. Its location depended on the presence of the `--outdir` parameter.
- Adapt `merge_vocab` to work with vocabularies split to a directory of files with `voc4cat transform --split`.

Closes #143