### PR TITLE
Improve consistency of log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,19 @@
 # Change log
 
-## Release 0.6.x (2023-08-dd)
+## Release 0.6.1 (2023-08-10)
 
 New features:
 
-- The `merge_vocab` script gained support for directories containing vocabularies created with `voc4cat transform --split`. This feature is used in gh-actions of [voc4cat-template](https://github.com/nfdi4cat/voc4cat-template)-based vocabularies.
+- The `merge_vocab` script gained support for directories containing vocabularies created with `voc4cat transform --split`. This feature is used in gh-actions of [voc4cat-template](https://github.com/nfdi4cat/voc4cat-template)-based vocabularies. #144
 
 Changes:
 
-- The log file will now always be written to the given directory. Previously the log file directory depended on the presence of the `--outdir` option.
+- The use of logging levels was made more consistent: Success of an operation is now logged for all operation on INFO level. #145
+- The log file will now always be written to the given directory. Previously the log file directory depended on the presence of the `--outdir` option. #144
 
 Bug fixes:
 
-- Sub-command `voc4cat docs` failed if `--outdir` was not given.
+- Sub-command `voc4cat docs` failed if `--outdir` was not given. #143 #144
 
 ## Release 0.6.0 (2023-08-09)
 

--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -35,7 +35,7 @@ def check_xlsx(fpath: Path, outfile: Path) -> int:
       different. This condition is fulfilled when no language is used more
       than once per concept.
     """
-    logger.info("Running check of Concepts sheet for file %s", fpath)
+    logger.debug("Running check of Concepts sheet for file %s", fpath)
     wb = openpyxl.load_workbook(fpath)
     is_supported_template(wb)
     ws = wb["Concepts"]
@@ -83,7 +83,7 @@ def check_xlsx(fpath: Path, outfile: Path) -> int:
         logger.info("-> Saved file with highlighted errors as %s", outfile)
         return
 
-    logger.info("-> Extended xlsx checks passed successfully.")
+    logger.info("-> xlsx check passed for file: %s", fpath)
 
 
 def ci_post(args):
@@ -99,7 +99,7 @@ def ci_post(args):
             )
             continue
         check_for_removed_iris(prev, new)
-        logger.info("-> Check ci-post passed.")
+    logger.info("-> Check ci-post passed.")
 
 
 # ===== check command & helpers to validate cmd options =====
@@ -121,7 +121,7 @@ def _check_ci_args(args):
 
 
 def check(args):
-    logger.info("Check subcommand started!")
+    logger.debug("Check subcommand started!")
 
     _check_ci_args(args)
 
@@ -170,7 +170,7 @@ def check(args):
 
     # validate rdf files with profile/pyshacl
     for file in rdf_files:
-        logger.info("Running SHACL validation for file %s", file)
+        logger.debug("Running SHACL validation for file %s", file)
         validate_with_profile(
             str(file), profile=args.profile, error_level=args.fail_at_level
         )

--- a/src/voc4cat/cli.py
+++ b/src/voc4cat/cli.py
@@ -38,7 +38,7 @@ def process_common_options(args, raw_args):
             logfile.parents[0].mkdir(exist_ok=True, parents=True)
         setup_logging(loglevel, logfile)
 
-    logger.debug("Executing cmd: voc4cat %s", " ".join(raw_args))
+    logger.info("Executing cmd: voc4cat %s", " ".join(raw_args))
     logger.debug("Processing common options.")
 
     # load config

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -1,4 +1,5 @@
 import logging
+from itertools import chain
 from pathlib import Path
 from typing import Dict, Literal, Union
 
@@ -417,7 +418,7 @@ def _check_convert_args(args):
 
 
 def convert(args):
-    logger.info("Convert subcommand started!")
+    logger.debug("Convert subcommand started!")
 
     _check_convert_args(args)
 
@@ -425,9 +426,9 @@ def convert(args):
     xlsx_files = [f for f in files if f.suffix.lower() in EXCEL_FILE_ENDINGS]
     rdf_files = [f for f in files if f.suffix.lower() in RDF_FILE_ENDINGS]
 
-    # convert xlsx files
-    for file in files:
-        logger.info('Processing "%s"', file)
+    # convert xlsx and rdf files
+    for file in chain(xlsx_files, rdf_files):
+        logger.debug('Processing "%s"', file)
         outfile = file if args.outdir is None else args.outdir / file.name
 
         if file in xlsx_files:
@@ -439,5 +440,3 @@ def convert(args):
             output_file_path = outfile.with_suffix(".xlsx")
             rdf_to_excel(file, output_file_path, template_file_path=args.template)
             logger.info("-> successfully converted to %s", output_file_path)
-        else:  # other files
-            logger.debug("-> nothing to do for this file type!")

--- a/src/voc4cat/docs.py
+++ b/src/voc4cat/docs.py
@@ -13,7 +13,6 @@ def run_pylode(turtle_file: Path, output_path: Path) -> None:
     """
     import pylode
 
-    logger.info("Building pyLODE documentation for %s", turtle_file)
     filename = Path(turtle_file)  # .resolve())
     outdir = output_path / filename.stem
     outdir.mkdir(exist_ok=True)
@@ -35,7 +34,8 @@ def run_pylode(turtle_file: Path, output_path: Path) -> None:
     )
     with open(outfile, "w") as html_file:
         html_file.write(content)
-    logger.info("-> %s", outfile.resolve().as_uri())
+
+    logger.info("-> built pyLODE documentation for %s", turtle_file)
 
 
 def run_ontospy(turtle_file: Path, output_path: Path) -> None:
@@ -48,7 +48,6 @@ def run_ontospy(turtle_file: Path, output_path: Path) -> None:
 
     title = config.VOCAB_TITLE
 
-    logger.info("Building ontospy documentation for %s", turtle_file)
     specific_output_path = (Path(output_path) / Path(turtle_file).stem).resolve()
 
     g = ontospy.Ontospy(Path(turtle_file).resolve().as_uri())
@@ -60,13 +59,14 @@ def run_ontospy(turtle_file: Path, output_path: Path) -> None:
     viz = Dataviz(g, title=title)
     viz_path = os.path.join(specific_output_path, "dendro")
     viz.build(viz_path)  # => build and save docs/visualization.
+    logger.info("-> built ontospy documentation for %s", turtle_file)
 
 
 # ===== docs command =====
 
 
 def docs(args):
-    logger.info("Docs subcommand started!")
+    logger.debug("Docs subcommand started!")
 
     files = [args.VOCAB] if args.VOCAB.is_file() else [*Path(args.VOCAB).iterdir()]
     turtle_files = [f for f in files if f.suffix.lower() in (".turtle", ".ttl")]

--- a/src/voc4cat/merge_vocab.py
+++ b/src/voc4cat/merge_vocab.py
@@ -71,6 +71,7 @@ def main_cli(args=None) -> int:
         outbox.mkdir(exist_ok=True, parents=True)
         setup_logging(logfile=logfile)
 
+    logger.info("Executing cmd: merge_vocab %s", " ".join(args))
     if not has_outbox or not vocab.exists():
         logger.error(
             'This script requires both folders to exist: "%s" and "%s"', outbox, vocab

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -414,7 +414,7 @@ def _transform_rdf(file, args):
         )
         vocab_dir.mkdir(exist_ok=True)
         write_split_turtle(vocab_graph, vocab_dir)
-        logger.debug("-> wrote split vocabulary to: %s", vocab_dir)
+        logger.info("-> wrote split vocabulary to: %s", vocab_dir)
         if args.inplace:
             logger.debug("-> going to remove %s", file)
             file.unlink()
@@ -423,7 +423,7 @@ def _transform_rdf(file, args):
 
 
 def transform(args):
-    logger.info("Transform subcommand started!")
+    logger.debug("Transform subcommand started!")
 
     files = [args.VOCAB] if args.VOCAB.is_file() else [*Path(args.VOCAB).iterdir()]
     xlsx_files = [f for f in files if f.suffix.lower() in EXCEL_FILE_ENDINGS]
@@ -457,7 +457,7 @@ def transform(args):
                 else rdf_dir.with_suffix(".ttl")
             )
             vocab_graph.serialize(destination=str(dest), format="turtle")
-            logger.debug("-> joined vocabulary into: %s", dest)
+            logger.info("-> joined vocabulary into: %s", dest)
             if args.inplace:
                 logger.debug("-> going to remove %s", rdf_dir)
                 shutil.rmtree(rdf_dir, ignore_errors=True)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -18,7 +18,7 @@ from voc4cat.utils import ConversionError
 @pytest.mark.parametrize(
     ("test_file", "msg"),
     [
-        (CS_CYCLES, "Extended xlsx checks passed successfully."),
+        (CS_CYCLES, "xlsx check passed"),
         (
             CS_CYCLES_INDENT_IRI,
             'Same Concept IRI "ex:test/term1" used more than once for language "en"',

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -87,8 +87,3 @@ def test_template(monkeypatch, datadir, tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         main_cli(["convert", "-v", "--template", std_template, str(tmp_path)])
     assert "->" in caplog.text
-
-    caplog.clear()
-    with caplog.at_level(logging.DEBUG):
-        main_cli(["convert", "-v", str(tmp_path / "template.txt")])
-    assert "-> nothing to do for this file type!" in caplog.text


### PR DESCRIPTION
Some unimportant messages were logged at INFO level while important success messages were partly only logged at DEBUG instead of INFO level. This PR makes the approach to log-level-selection more consistent.