### PR TITLE
Add handling of split vocabularies for --ci-post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Release 0.6.2 (2023-08-10)
+
+New features:
+
+- Option `--ci-post` of sub-command `voc4cat check` was improved to detect and work with split vocabularies. #146
+
 ## Release 0.6.1 (2023-08-10)
 
 New features:

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -63,7 +63,7 @@ def write_split_turtle(vocab_graph: Graph, outdir: Path) -> None:
         logger.debug("-> wrote %i %ss-file(s).", len(qresults), skos_class)
 
 
-def read_split_turtle(vocab_dir: Path) -> Graph:
+def join_split_turtle(vocab_dir: Path) -> Graph:
     # Search recursively all turtle files belonging to the concept scheme
     turtle_files = vocab_dir.rglob("*.ttl")
     # Create an empty RDF graph to hold the concept scheme
@@ -450,7 +450,7 @@ def transform(args):
         logger.debug('Processing rdf files in "%s"', rdf_dir)
         # The if..else is not required now. It is a frame for future additions.
         if args.join:
-            vocab_graph = read_split_turtle(rdf_dir)
+            vocab_graph = join_split_turtle(rdf_dir)
             dest = (
                 (args.outdir / rdf_dir).with_suffix(".ttl").name
                 if args.outdir

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -128,6 +128,14 @@ def test_check_ci_post(datadir, tmp_path, temp_config, caplog):
         main_cli(["check", "-v", "--ci-post", str(previous), str(vocabdir)])
     assert "No removals detected." in caplog.text
 
+    caplog.clear()
+    (previous / "myvocab").mkdir()
+    shutil.copy(vocabdir / "myvocab.ttl", previous / "myvocab")
+    # Test with a split vocabulary in previous-dir
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["check", "-v", "--ci-post", str(previous), str(vocabdir)])
+    assert "-> previous version is a split vocabulary" in caplog.text
+
 
 def test_check_ci_pre_one_folder(tmp_path, caplog):
     with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):


### PR DESCRIPTION
This is important in gh-action of vocabularies based on [voc4cat/template](https://github.com/nfdi4cat/voc4cat-template) to detect if PRs include (forbidden) removal of concepts.