### PR TITLE
Expand tables in xlsx based on content

### DIFF
--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -14,7 +14,12 @@ from voc4cat.checks import (
 )
 from voc4cat.convert import validate_with_profile
 from voc4cat.transform import join_split_turtle
-from voc4cat.utils import EXCEL_FILE_ENDINGS, RDF_FILE_ENDINGS, is_supported_template
+from voc4cat.utils import (
+    EXCEL_FILE_ENDINGS,
+    RDF_FILE_ENDINGS,
+    adjust_length_of_tables,
+    is_supported_template,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +87,8 @@ def check_xlsx(fpath: Path, outfile: Path) -> int:
     if failed_checks:
         wb.save(outfile)
         logger.info("-> Saved file with highlighted errors as %s", outfile)
+        # Extend size (length) of tables in all sheets
+        adjust_length_of_tables(outfile)
         return
 
     logger.info("-> xlsx check passed for file: %s", fpath)

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -24,6 +24,7 @@ from voc4cat.utils import (
     EXCEL_FILE_ENDINGS,
     RDF_FILE_ENDINGS,
     ConversionError,
+    adjust_length_of_tables,
     has_file_in_multiple_formats,
     is_supported_template,
     load_template,
@@ -440,3 +441,5 @@ def convert(args):
             output_file_path = outfile.with_suffix(".xlsx")
             rdf_to_excel(file, output_file_path, template_file_path=args.template)
             logger.info("-> successfully converted to %s", output_file_path)
+            # Extend size (length) of tables in all sheets
+            adjust_length_of_tables(output_file_path)

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -20,7 +20,12 @@ from voc4cat.dag_util import (
     dag_to_node_levels,
     get_concept_and_level_from_indented_line,
 )
-from voc4cat.utils import EXCEL_FILE_ENDINGS, RDF_FILE_ENDINGS, is_supported_template
+from voc4cat.utils import (
+    EXCEL_FILE_ENDINGS,
+    RDF_FILE_ENDINGS,
+    adjust_length_of_tables,
+    is_supported_template,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -429,6 +434,9 @@ def _transform_xlsx(file, args):
         make_ids(file, outfile, prefix, start_id, base_iri)
     else:
         logger.debug("-> nothing to do for xlsx files!")
+
+    # Extend size (length) of tables in all sheets
+    adjust_length_of_tables(outfile)
 
 
 def _transform_rdf(file, args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,12 +86,18 @@ def test_nonexisting_config(monkeypatch, datadir, caplog):
 
 
 @mock.patch.dict(os.environ, {"LOGLEVEL": "DEBUG"})
-def test_valid_config(monkeypatch, datadir, caplog, temp_config):
+def test_valid_config(monkeypatch, datadir, caplog, tmp_path, temp_config):
     # Don't remove "temp_config". The fixture avoid global config change.
+    shutil.copy(datadir / CS_SIMPLE, tmp_path / CS_SIMPLE)
     monkeypatch.chdir(datadir)
     with caplog.at_level(logging.DEBUG):
         main_cli(
-            ["transform", "--config", str(datadir / "valid_idranges.toml"), CS_SIMPLE]
+            [
+                "transform",
+                "--config",
+                str(datadir / "valid_idranges.toml"),
+                str(tmp_path / CS_SIMPLE),
+            ]
         )
     assert "Config loaded from" in caplog.text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from voc4cat.utils import split_and_tidy
+from openpyxl import Workbook, load_workbook
+from openpyxl.worksheet.table import Table
+from voc4cat.utils import adjust_length_of_tables, split_and_tidy
 
 
 def test_default_action():
@@ -11,3 +13,27 @@ def test_default_action():
 def test_trailing_comma():
     assert split_and_tidy("a,") == ["a"]
     assert split_and_tidy("a,b,") == ["a", "b"]
+
+
+def test_expand_tables(tmp_path):
+    test_wb = tmp_path / "table.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Letter", "value"])  # table header
+    data = [
+        ["A", 1],
+        ["B", 2],
+    ]
+    for row in data:
+        ws.append(row)
+    tab = Table(displayName="Table1", ref="A1:B3")
+    ws.add_table(tab)
+    ws["A5"] = "X"
+    wb.save(test_wb)
+
+    adjust_length_of_tables(test_wb)
+
+    wb = load_workbook(test_wb)
+    name, table_range = wb.active.tables.items()[0]
+    assert name == "Table1"
+    assert table_range == "A1:B5"


### PR DESCRIPTION
Whenever xlsx files are saved, the tables are expanded (in length) to include all data. The use of tables remains optional.

Closes #155