### PR TITLE
Add testing with py 3.12 pre-releases to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,15 @@ jobs:
         python-version:
         - '3.10'
         - '3.11'
-
+        - '3.12'
     steps:
     - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+        cache: pip
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This is for preliminary testing. We have to wait with merging until all dependencies are ready for 3.12.