### PR TITLE
Fix zenodo and citation metadata.

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,13 +24,12 @@
   "keywords": [
     "SKOS", "vocabulary", "spreadsheet", "xlsx", "linked data", "rdf"
   ],
-  "language": "python",
   "license": "BSD-3-clause",
   "related_identifiers": [
     {
         "identifier": "doi:10.5281/zenodo.8306845",
         "relation": "isRequiredBy",
-        "resource_type": "software",
+        "resource_type": "workflow",
         "scheme": "doi"
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ New features:
 
 Changes:
 
-- Replaced CITATION.cff by CITATION.bib to avoid side effects on data in Zenodo. #166, #167
-- Provide metadata for Zenodo completely via `.zenodo.json`. The metadata have also been enriched significantly. #167
+- Replaced CITATION.cff by CITATION.bib to avoid side effects on data in Zenodo. #166, #167, #168
+- Provide metadata for Zenodo completely via `.zenodo.json`. The metadata have also been enriched significantly. #167, #168
 
 ## Release 0.7.4 (2023-08-31)
 

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,5 +1,8 @@
-@software{david linke_peter philips_nicholas car_jamie feiss_2023,
-  author       = {David Linke and Peter Philips and Nicholas Car and Jamie Feiss},
+@misc{@software{david_linke_8277925,
+  author       = {David Linke and
+                  Peter Philips and
+                  Nicholas Car and
+                  Jamie Feiss},
   title        = {nfdi4cat/voc4cat-tool - A command-line tool written in Python for
                   creating and maintaining SKOS-vocabularies with Excel and GitHub.},
   abstractNote = {The voc4cat tool can be run locally but is also well suited for
@@ -8,10 +11,9 @@
                   (nfdi4cat/voc4cat). Supported features include conversion between
                   SKOS/turtle and Excel/xlsx, validation, transformations between
                   different representations and documentation generation.},
-  year         = {2023},
-  month        = {Aug},
+  year         = {2022--2023},
   publisher    = {Zenodo},
   version      = {v0.7.4},
-  doi          = {10.5281/zenodo.8306813},
-  url          = {https://doi.org/10.5281/zenodo.8306813}
+  doi          = {10.5281/zenodo.8277925},
+  url          = {https://doi.org/10.5281/zenodo.8277925}
 }


### PR DESCRIPTION
Change CITATION.bib to refer to the "all-versions" DOI. Citation information for specific versions is available on Zenodo if required.

This also removes the "language" key in the Zenodo metadata since language revers to spoken language but not to the programming language.

Closes #166