### PR TITLE
Fix case of license specifier for zenodo / changelog-link for pypi

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,7 +24,7 @@
   "keywords": [
     "SKOS", "vocabulary", "spreadsheet", "xlsx", "linked data", "rdf"
   ],
-  "license": "BSD-3-clause",
+  "license": "BSD-3-Clause",
   "related_identifiers": [
     {
         "identifier": "doi:10.5281/zenodo.8306845",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
-## Release 0.7.5 (2023-09-02)
+## Release 0.7.5 / 0.7.6 (2023-09-03)
+
+In 0.7.6 we fixed the license specifier for Zenodo and the link to the changelog for PyPI.
 
 New features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dynamic = ["version"]
 [project.urls]
 Homepage = "https://github.com/nfdi4cat/voc4cat-tool/"
 Documentation = "https://github.com/nfdi4cat/voc4cat-tool/"
-Changelog = "https://github.com/nfdi4cat/voc4cat-tool/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/nfdi4cat/voc4cat-tool/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 tests = [


### PR DESCRIPTION
This small change should fix the Zenodo integration. Release 0.7.5 was rejected because of an invalid license specifier.