### PR TITLE
Consistent validation with pydantic & vocpub (disallow None)

### DIFF
--- a/src/voc4cat/models.py
+++ b/src/voc4cat/models.py
@@ -56,7 +56,7 @@ def reset_curies(curies_map: dict) -> None:
 def split_curie_list(cls, v):
     if v is None:
         return []
-    if type(v) is list:
+    if isinstance(v, list):
         return v
     return (p.strip() for p in v.split(","))
 
@@ -149,11 +149,11 @@ class ConceptScheme(BaseModel):
     title: str
     description: str
     created: datetime.date
-    modified: datetime.date = None
+    modified: datetime.date
     creator: Ror | Orcid | str
     publisher: Ror | str
     provenance: str
-    version: str = None
+    version: str = "automatic"
     custodian: str = None
     pid: str = None
     vocab_name: str = Field("", exclude=True)
@@ -170,8 +170,8 @@ class ConceptScheme(BaseModel):
 
     @validator("modified")
     def set_modified_date_if_missing(cls, v):
-        if os.getenv("CI") is not None:  # Don't track modified date in GitHub.
-            v = None
+        if os.getenv("VOC4CAT_VERSION") is not None:
+            v = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
         return v
 
     @validator("publisher")
@@ -187,7 +187,7 @@ class ConceptScheme(BaseModel):
     @validator("version")
     def version_from_env(cls, v):
         if os.getenv("CI") is not None:  # Don't track version in GitHub.
-            v = None
+            v = "automatic"
         version_from_env = os.getenv("VOC4CAT_VERSION")
         if version_from_env is not None:
             if not version_from_env.startswith("v"):

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -78,12 +78,12 @@ def autoversion_cs(graph: Graph) -> Graph:
         date_modified = os.getenv("VOC4CAT_MODIFIED")
         graph.add((cs, DCTERMS.modified, Literal(date_modified, datatype=XSD.date)))
     if os.getenv("VOC4CAT_VERSION") is not None:
-        graph.remove((None, OWL.versionInfo, None))
         version = os.getenv("VOC4CAT_VERSION")
         if version is not None and not version.startswith("v"):
             msg = 'Invalid environment variable VOC4CAT_VERSION "%s". Version must start with letter "v".'
             logger.error(msg, version)
             raise Voc4catError(msg % version)
+        graph.remove((None, OWL.versionInfo, None))
         graph.add(
             (cs, OWL.versionInfo, Literal(version)),
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -119,8 +119,8 @@ def test_vocabulary_valid_in_ci():
         custodian="Vance Kelly",
         pid="http://pid.geoscience.gov.au/dataset/ga/114541",
     )
-    assert cs.modified is None
-    assert cs.version is None
+    assert cs.modified == datetime.date(2020, 4, 4)
+    assert cs.version == "automatic"
 
 
 @mock.patch.dict(os.environ, {"CI": "", "VOC4CAT_VERSION": "v2023-08-15"})
@@ -138,7 +138,9 @@ def test_vocabulary_valid_version_via_envvar():
         custodian="Vance Kelly",
         pid="http://pid.geoscience.gov.au/dataset/ga/114541",
     )
-    assert cs.modified is None
+    assert cs.modified == datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%d"
+    )
     assert cs.version == "v2023-08-15"
 
 

--- a/tests/test_template043.py
+++ b/tests/test_template043.py
@@ -18,7 +18,7 @@ def test_empty_template():
             test_file,
             output_type="file",
         )
-    assert "7 validation errors for ConceptScheme" in str(e)
+    assert "9 validation errors for ConceptScheme" in str(e)
 
 
 def test_simple():


### PR DESCRIPTION
None is not allowed according to the vocpub profile but the pydantic model accepted it. The pydantic model is changed to also only allow dates. Two tests were wrong and have been changed.

This PR also changes the default version of the concept scheme in CI from `None` to the string `"automatic"` which conveys more clearly what is happening: The version is automatically derived and added to the build artifacts but not present in git.

Closes #174