### PR TITLE
Add coverage summary as job output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,15 @@ jobs:
         with:
           name: coverage-data
 
-      - name: Combine coverage and fail if less than 100%
+      - name: Combine coverage, create reports and fail if less than threshold.
         run: |
           python -m coverage combine
-          python -m coverage html --skip-empty --skip-covered
-          # By merging files from vocexcel in #119 coverage dropped from 100% to 93%.
+          python -m coverage html --skip-empty
+          echo '## Test Coverage Report' >> $GITHUB_STEP_SUMMARY
+          python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+
+          # Merging files from vocexcel in #119 reduced coverage from 100% to 93%.
+          # We are working on getting back to full coverage.
           python -m coverage report --fail-under=97
 
       - name: Upload HTML report


### PR DESCRIPTION
Coverage can produce [markdown reports](https://coverage.readthedocs.io/en/latest/cmd.html#cmd-report) which can be easily [shown on the job summary page](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary). I like this more than putting coverage summaries into PR messages.