### PR TITLE
Make example vocab pass validation with vocpub-4.7

### DIFF
--- a/example/photocatalysis_example.ttl
+++ b/example/photocatalysis_example.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sdo: <https://schema.org/> .
 
 <https://example.org/0000004> a skos:Concept ;
     dcterms:identifier "0000004"^^xsd:token ;
@@ -567,6 +568,8 @@
     skos:prefLabel "ultraviolet"@en .
 
 <https://example.org/0000108> a skos:Collection ;
+    rdfs:isDefinedBy <https://example.org> ;
+    skos:inScheme <https://example.org> ;
     dcterms:identifier "0000108"^^xsd:token ;
     dcterms:isPartOf <https://example.org> ;
     dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
@@ -1191,13 +1194,17 @@
         <https://example.org/0000061> ;
     skos:prefLabel "characterization"@en .
 
+<http://example.org/nfdi4cat/> a sdo:Organization ;
+    sdo:name "NFDI4Cat" ;
+    sdo:url "https://nfdi4cat.org"^^xsd:anyURI .
+
 <https://example.org> a skos:ConceptScheme ;
     dcterms:created "2023-06-29"^^xsd:date ;
     dcterms:creator <http://example.org/nfdi4cat/> ;
     dcterms:hasPart <https://example.org/0000108> ;
     dcterms:identifier "example.org"^^xsd:token ;
     dcterms:modified "2023-06-29"^^xsd:date ;
-    dcterms:provenance """https://orcid.org/0000-0002-6242-2167 Nikolaos G. Moustakas,
+    skos:historyNote """https://orcid.org/0000-0002-6242-2167 Nikolaos G. Moustakas,
 0000-0002-5898-1820 David Linke"""@en ;
     dcterms:publisher <http://example.org/nfdi4cat/> ;
     owl:versionInfo "v2023-06-29" ;

--- a/example/photocatalysis_example.ttl
+++ b/example/photocatalysis_example.ttl
@@ -2,560 +2,559 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix sdo: <https://schema.org/> .
 
 <https://example.org/0000004> a skos:Concept ;
     dcterms:identifier "0000004"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000005> ;
     skos:broader <https://example.org/0000003> ;
     skos:definition "A chemical compound formed by the reaction of a metal with oxygen."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "metal oxide"@en .
 
 <https://example.org/0000006> a skos:Concept ;
     dcterms:identifier "0000006"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000007> ;
     skos:altLabel "EF"@en ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "The energy level in a semiconductor where the probability of finding an electron is 0.5. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "Fermi level"@en .
 
 <https://example.org/0000007> a skos:Concept ;
     dcterms:identifier "0000007"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000008> ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "The degree of a three-dimensional structural order of atoms which constitute the crystal lattice of a material."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "crystallinity"@en .
 
 <https://example.org/0000008> a skos:Concept ;
     dcterms:identifier "0000008"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000009> ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "Pore size distribution refers to the range of pore sizes in a material. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "pore size distribution"@en .
 
 <https://example.org/0000009> a skos:Concept ;
     dcterms:identifier "0000009"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000010> ;
     skos:altLabel "energy bandgap; Eg"@en ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "The energy difference between a semiconductor’s valence band top and conduction band bottom, which is required to excite an electron from the former to the latter.  "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "bandgap energy"@en .
 
 <https://example.org/0000010> a skos:Concept ;
     dcterms:identifier "0000010"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000011> ;
     skos:altLabel "VB"@en ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "The band of energy levels in a solid fully occupied by electrons at 0 K (273.15 °C)."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "valence band"@en .
 
 <https://example.org/0000011> a skos:Concept ;
     dcterms:identifier "0000011"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000012> ;
     skos:altLabel "CB"@en ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "The energy band of electronic levels of partially or fully filled mobile electrons in a metal or a semiconductor. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "conduction band"@en .
 
 <https://example.org/0000012> a skos:Concept ;
     dcterms:identifier "0000012"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000013> ;
     skos:altLabel "SSA"@en ;
     skos:broader <https://example.org/0000005> ;
     skos:definition "Α measure of the total surface area of a material per unit mass or volume."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "specific surface area"@en .
 
 <https://example.org/0000014> a skos:Concept ;
     dcterms:identifier "0000014"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000015> ;
     skos:broader <https://example.org/0000013> ;
     skos:definition "The introduction of foreign atoms into a semiconductor leading to the formation of new energy levels and charge concentrations."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "doping"@en .
 
 <https://example.org/0000017> a skos:Concept ;
     dcterms:identifier "0000017"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000018> ;
     skos:broader <https://example.org/0000016> ;
     skos:definition "Mass of a powdered photocatalyst used for an experiment."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "powder mass"@en .
 
 <https://example.org/0000020> a skos:Concept ;
     dcterms:identifier "0000020"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000021> ;
     skos:altLabel "spray-coating"@en ;
     skos:broader <https://example.org/0000019> ;
     skos:definition "A technique used to deposit uniform thin films onto a substrate by spraying a solution of the material onto the surface."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "spray coating"@en .
 
 <https://example.org/0000021> a skos:Concept ;
     dcterms:identifier "0000021"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000022> ;
     skos:broader <https://example.org/0000019> ;
     skos:definition "A tape-casting method used to deposit thin films of a photocatalyst onto the surface of a substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "doctor blading"@en .
 
 <https://example.org/0000022> a skos:Concept ;
     dcterms:identifier "0000022"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000023> ;
     skos:altLabel "spin casting"@en,
         "spin-casting"@en,
         "spin-coating"@en ;
     skos:broader <https://example.org/0000019> ;
     skos:definition "A technique used to deposit uniform thin films onto a substrate (e.g., metal or glass) by spinning at high speeds a solution (paste) of the material onto the surface."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "spin coating"@en .
 
 <https://example.org/0000025> a skos:Concept ;
     dcterms:identifier "0000025"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000026> ;
     skos:broader <https://example.org/0000024> ;
     skos:definition "A  flat surface made of a metal (e.g., titanium, stainless steel) serving as a substrate for the deposition of a photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "metallic substrate"@en .
 
 <https://example.org/0000027> a skos:Concept ;
     dcterms:identifier "0000027"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000028> ;
     skos:altLabel "FTO; FTO glass"@en ;
     skos:broader <https://example.org/0000026> ;
     skos:definition "Transparent conductive metal oxide (fluorine doped tin oxide) that can be used in the fabrication of transparent electrodes for thin films."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "fluorine doped tin oxide coated glass"@en .
 
 <https://example.org/0000028> a skos:Concept ;
     dcterms:identifier "0000028"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000029> ;
     skos:altLabel "ITO; ITO glass"@en ;
     skos:broader <https://example.org/0000026> ;
     skos:definition "Transparent conductive metal oxide (indium tin oxide) that can be used in the fabrication of transparent electrodes for thin films."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "indium tin oxide coated glass"@en .
 
 <https://example.org/0000029> a skos:Concept ;
     dcterms:identifier "0000029"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000030> ;
     skos:broader <https://example.org/0000026> ;
     skos:definition "A resistant to thermal shock type of glass, composed mainly of silica and boron trioxide."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "borosilicate glass"@en .
 
 <https://example.org/0000030> a skos:Concept ;
     dcterms:identifier "0000030"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000031> ;
     skos:altLabel "quartz"@en ;
     skos:broader <https://example.org/0000026> ;
     skos:definition "A type of pure silicon dioxide, highly crystalline glass that allows the transmission of light in the UV wavelength range."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "quartz glass"@en .
 
 <https://example.org/0000031> a skos:Concept ;
     dcterms:identifier "0000031"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000032> ;
     skos:broader <https://example.org/0000024> ;
     skos:definition "A  surface made of a ceramic material (e.g., alumina) serving as a substrate for the deposition of a photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "ceramic substrate"@en .
 
 <https://example.org/0000033> a skos:Concept ;
     dcterms:identifier "0000033"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000034> ;
     skos:broader <https://example.org/0000032> ;
     skos:definition "The width of the substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "substrate width"@en .
 
 <https://example.org/0000034> a skos:Concept ;
     dcterms:identifier "0000034"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000035> ;
     skos:broader <https://example.org/0000032> ;
     skos:definition "The depth of the substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "substrate depth"@en .
 
 <https://example.org/0000035> a skos:Concept ;
     dcterms:identifier "0000035"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000036> ;
     skos:broader <https://example.org/0000032> ;
     skos:definition "The thickness of the substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "substrate thickness"@en .
 
 <https://example.org/0000036> a skos:Concept ;
     dcterms:identifier "0000036"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000037> ;
     skos:altLabel "substrate surface area"@en ;
     skos:broader <https://example.org/0000032> ;
     skos:definition "The surface area of the substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "substrate area"@en .
 
 <https://example.org/0000038> a skos:Concept ;
     dcterms:identifier "0000038"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000039> ;
     skos:broader <https://example.org/0000037> ;
     skos:definition "Mass of catalyst deposited onto the surface of a substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "thin film mass"@en .
 
 <https://example.org/0000040> a skos:Concept ;
     dcterms:identifier "0000040"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000041> ;
     skos:broader <https://example.org/0000039> ;
     skos:definition "The width of the film of the deposited photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "thin film width"@en .
 
 <https://example.org/0000041> a skos:Concept ;
     dcterms:identifier "0000041"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000042> ;
     skos:broader <https://example.org/0000039> ;
     skos:definition "The thickness of the film of the deposited photocatalyst. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "thin film thickness"@en .
 
 <https://example.org/0000042> a skos:Concept ;
     dcterms:identifier "0000042"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000043> ;
     skos:broader <https://example.org/0000039> ;
     skos:definition "The depth of the film of the deposited photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "thin film depth"@en .
 
 <https://example.org/0000043> a skos:Concept ;
     dcterms:identifier "0000043"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000044> ;
     skos:broader <https://example.org/0000039> ;
     skos:definition "The area of the substrate covered by the deposited photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "thin film area"@en .
 
 <https://example.org/0000063> a skos:Concept ;
     dcterms:identifier "0000063"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000085> ;
     skos:broader <https://example.org/0000062> ;
     skos:definition "Τhe lowest energy state of a system. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "ground state"@en .
 
 <https://example.org/0000064> a skos:Concept ;
     dcterms:identifier "0000064"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000086> ;
     skos:broader <https://example.org/0000062> ;
     skos:definition "Τhe temporary state of a system with higher energy than its ground state caused by an external factor. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "excited state"@en .
 
 <https://example.org/0000066> a skos:Concept ;
     dcterms:identifier "0000066"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000088> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The transfer of an electron initiated by the absorption of a photon of sufficient energy. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "photoinduced electron transfer"@en .
 
 <https://example.org/0000067> a skos:Concept ;
     dcterms:identifier "0000067"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000089> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The transfer of a hole initiated by the absorption of a photon of sufficient energy. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "photoinduced hole transfer"@en .
 
 <https://example.org/0000068> a skos:Concept ;
     dcterms:identifier "0000068"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000090> ;
     skos:altLabel "charge photogeneration; photogenerated charges; charge photo-generation; electron excitation; electron-hole pair;"@en ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The generation of electron - hole pairs in a semiconductor as a result of light absorption of sufficient energy to overcome the bandgap energy. Electrons (negative charge) get excited to the conduction band, while holes (positive charge) remain in the valence band. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "photoinduced charge generation"@en .
 
 <https://example.org/0000069> a skos:Concept ;
     dcterms:identifier "0000069"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000091> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The process by which photogenerated charges (electrons and holes) in a semiconductor recombine, resulting in the dissipation of energy in the form of e.g., heat or light. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "charge recombination"@en .
 
 <https://example.org/0000070> a skos:Concept ;
     dcterms:identifier "0000070"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000092> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "Absorption is the process in which energy (e.g., photons) or an absorbent (e.g., a gas) is taken up by an absorbate. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "absorption"@en .
 
 <https://example.org/0000071> a skos:Concept ;
     dcterms:identifier "0000071"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000093> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The binding (strong or weak) of a pollutant or a reactant molecule on the surface of a photocatalyst which facilitates the performance of photocatalytic reactions."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "adsorption"@en .
 
 <https://example.org/0000072> a skos:Concept ;
     dcterms:identifier "0000072"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000094> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The process under which reactants, intermediates and products are released from the surface of the photocatalyst. Desoprtion can be facilitated by an increase in temperature or a change in the pH."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "desorption"@en .
 
 <https://example.org/0000073> a skos:Concept ;
     dcterms:identifier "0000073"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000095> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The process of separating positive and negative charges in a semiconductor, typically as a result of an external force, (e.g., photoexcitation). "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "charge separation"@en .
 
 <https://example.org/0000074> a skos:Concept ;
     dcterms:identifier "0000074"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000096> ;
     skos:altLabel "photo-excitation"@en ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The state caused by the transition of electrons from the valence band top to the conduction band bottom by absorption of photons of sufficient energy.  "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "photoexcitation"@en .
 
 <https://example.org/0000075> a skos:Concept ;
     dcterms:identifier "0000075"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000097> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The loss of electrons or an increase in the oxidation state of a species. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "oxidation"@en .
 
 <https://example.org/0000077> a skos:Concept ;
     dcterms:identifier "0000077"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000099> ;
     skos:altLabel "photocatalytic carbon dioxide reduction; CO2 photoreduction; carbon dioxide photoreduction; artificial photosynthesis"@en ;
     skos:broader <https://example.org/0000076> ;
     skos:definition "The light-driven reduction (conversion) of carbon dioxide (CO2) to hydrocarbons and / or platform chemicals in presence of water. The absorption of light and the adsorption of the reactants is performed by a photocatalyst (usually a metal oxide). "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "photocatalytic CO2 reduction"@en .
 
 <https://example.org/0000084> a skos:Concept ;
     dcterms:identifier "0000084"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000153> ;
     skos:broader <https://example.org/0000083> ;
     skos:definition "Volume of the reaction chamber, calculated by its dimensions. Volume of pipes and valves connected to the reaction chamber should also be calculated and added to the total volume. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "reaction chamber volume"@en .
 
 <https://example.org/0000085> a skos:Concept ;
     dcterms:identifier "0000085"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000154> ;
     skos:broader <https://example.org/0000083> ;
     skos:definition "Height, width and depth (in cubic- or rectangular- shaped reaction chambers) or diameter and height (in cylindrer - shaped reaction chambers)"@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "reaction chamber dimension"@en .
 
 <https://example.org/0000086> a skos:Concept ;
     dcterms:identifier "0000086"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000155> ;
     skos:broader <https://example.org/0000083> ;
     skos:definition "The shape of the reaction chamber. In gas-phase reactions, reaction chambers have usually a cylindrical, cubical or rectangular shape."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "reaction chamber shape"@en .
 
 <https://example.org/0000087> a skos:Concept ;
     dcterms:identifier "0000087"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000156> ;
     skos:broader <https://example.org/0000083> ;
     skos:definition "Material used for the construction of the main body of the reaction chamber."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "reaction chamber material"@en .
 
 <https://example.org/0000089> a skos:Concept ;
     dcterms:identifier "0000089"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000158> ;
     skos:broader <https://example.org/0000088> ;
     skos:definition "Material that the window is made of. The window, usually attached to the lid sealing the reaction chamber, allows for the incoming light to enter the reaction chamber and interact with the photocatalyst. The material of the window influences the wavelenth range the the photocatalyst experieneces. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "optical window material"@en .
 
 <https://example.org/0000091> a skos:Concept ;
     dcterms:identifier "0000091"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000160> ;
     skos:broader <https://example.org/0000090> ;
     skos:definition "Diameter of the optical window allowing the incoming light to enter the reaction chamber and interact with the photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "optical window diameter"@en .
 
 <https://example.org/0000092> a skos:Concept ;
     dcterms:identifier "0000092"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000161> ;
     skos:broader <https://example.org/0000090> ;
     skos:definition "Thickness of the optical window allowing the incoming light to enter the reaction chamber and interact with the photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "optical window thickness"@en .
 
 <https://example.org/0000095> a skos:Concept ;
     dcterms:identifier "0000095"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000167> ;
     skos:altLabel "Hg-Xe lamp"@en,
         "Hg/Xe lamp"@en,
         "mercury xenon lamp"@en ;
     skos:broader <https://example.org/0000094> ;
     skos:definition "A lamp containing a mixture of mercury (Hg) and xenon (Xe) gases. Under electric current, the gas mixture gets ionized through a discharge electric charge creating a plasma generating UV and visible light. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "mercury-xenon lamp"@en .
 
 <https://example.org/0000096> a skos:Concept ;
     dcterms:identifier "0000096"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000168> ;
     skos:altLabel "Xe lamp"@en,
         "Xe-lamp"@en ;
     skos:broader <https://example.org/0000094> ;
     skos:definition "A lamp containing pure xenon (Xe) gas. Under electric current, the gas mixture gets ionized through a discharge electric charge creating a plasma generating UV and visible light. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "xenon lamp"@en .
 
 <https://example.org/0000097> a skos:Concept ;
     dcterms:identifier "0000097"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000169> ;
     skos:altLabel "LED"@en,
         "light-emitting diode"@en ;
     skos:broader <https://example.org/0000094> ;
     skos:definition "A solid-state semiconductor emitting light at highly controllable (narrow) wavelength ranges."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "light emitting diode"@en .
 
 <https://example.org/0000099> a skos:Concept ;
     dcterms:identifier "0000099"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000171> ;
     skos:broader <https://example.org/0000098> ;
     skos:definition "The distance of the light source from the reaction chamber and the photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "light source distance"@en .
 
 <https://example.org/0000100> a skos:Concept ;
     dcterms:identifier "0000100"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000172> ;
     skos:broader <https://example.org/0000098> ;
     skos:definition "The value of current (usually in A or mA) used to operate the selected light source."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "light operation current"@en .
 
 <https://example.org/0000101> a skos:Concept ;
     dcterms:identifier "0000101"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000173> ;
     skos:broader <https://example.org/0000098> ;
     skos:definition "The value of voltage  (usually in V or mV) used to operate the selected light source."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "light operation voltage"@en .
 
 <https://example.org/0000102> a skos:Concept ;
     dcterms:identifier "0000102"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000174> ;
     skos:broader <https://example.org/0000098> ;
     skos:definition "The power of the light source (usually in W or mW). The power can be calculated by the multiplication of the current and voltage used to operate the light source,"@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "light power output"@en .
 
 <https://example.org/0000103> a skos:Concept ;
     dcterms:identifier "0000103"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000175> ;
     skos:broader <https://example.org/0000098> ;
     skos:definition "The light intensity (usually in mW cm-2) of the selected light source. The light intensity should be measured at the same distance as the one between the light source and the reaction chamber / sample."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "light intensity"@en .
 
 <https://example.org/0000105> a skos:Concept ;
     dcterms:identifier "0000105"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000177> ;
     skos:altLabel "IR; Ir"@en ;
     skos:broader <https://example.org/0000104> ;
     skos:definition "Electromagnetic radiation with wavelengths typically in the range of 800 nm - 20000 nm."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "infrared"@en .
 
 <https://example.org/0000106> a skos:Concept ;
     dcterms:identifier "0000106"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000178> ;
     skos:altLabel "Vis; VIS"@en ;
     skos:broader <https://example.org/0000104> ;
     skos:definition "Electromagnetic radiation with wavelengths visible to the human eye, typically in the range of 400-800 nm. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "visible"@en .
 
 <https://example.org/0000107> a skos:Concept ;
     dcterms:identifier "0000107"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000179> ;
     skos:altLabel "UV"@en,
         "UV-A"@en,
@@ -564,16 +563,17 @@
         "VUV"@en ;
     skos:broader <https://example.org/0000104> ;
     skos:definition "Electromagnetic radiation with a wavelength typically in the range of 100-400 nanometers."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "ultraviolet"@en .
 
 <https://example.org/0000108> a skos:Collection ;
-    rdfs:isDefinedBy <https://example.org> ;
-    skos:inScheme <https://example.org> ;
     dcterms:identifier "0000108"^^xsd:token ;
     dcterms:isPartOf <https://example.org> ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
+    rdfs:isDefinedBy <https://example.org> ;
     skos:definition "A collection of concepts referring to material  characterization techniques and methods to evaluate their efficiency in photocatalysis."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
+    skos:inScheme <https://example.org> ;
     skos:member <https://example.org/0000045>,
         <https://example.org/0000046>,
         <https://example.org/0000047>,
@@ -596,39 +596,42 @@
         <https://example.org/0000082> ;
     skos:prefLabel "Characterization and evaluation techniques"@en .
 
+<http://example.org/nfdi4cat/> a schema:Organization ;
+    schema:name "http://example.org/nfdi4cat/"@en ;
+    schema:url "http://example.org/nfdi4cat/"^^xsd:anyURI .
+
 <https://example.org/0000003> a skos:Concept ;
     dcterms:identifier "0000003"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000004> ;
     skos:broader <https://example.org/0000002> ;
     skos:definition "Broad families of semiconduction materials (e.g., metal oxides) that can be used as photocatalysts in various applications."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000004> ;
     skos:prefLabel "categories of semiconductors"@en .
 
 <https://example.org/0000013> a skos:Concept ;
     dcterms:identifier "0000013"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000014> ;
     skos:broader <https://example.org/0000002> ;
     skos:definition "Techniques used to modify the properties of a photocatalyst, with the aim to increase its efficiency in a photocatalytic application. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000014> ;
     skos:prefLabel "modification technique"@en .
 
 <https://example.org/0000016> a skos:Concept ;
     dcterms:identifier "0000016"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000017> ;
     skos:broader <https://example.org/0000015> ;
     skos:definition "A photocatalyst introduced to the reaction chamber in the form of a powder. Usually the powdered photocatalyst is spread inside a quartz / glass plate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000017> ;
     skos:prefLabel "powdered photocatalyst"@en .
 
 <https://example.org/0000045> a skos:Concept ;
     dcterms:identifier "0000045"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000067> ;
     skos:altLabel "X-ray emission spectrometry"@en,
         "X-ray fluorescence spectrometry; X-ray fluorescence spectroscopy"@en,
@@ -639,22 +642,22 @@
         "XRF spectroscopy"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A non-destructive analytical technique which uses a high-energy X-ray source to expose a material and monitors the emitted characteristic fluorescent X-Rays.  "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "X-ray fluorescence"@en .
 
 <https://example.org/0000046> a skos:Concept ;
     dcterms:identifier "0000046"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000068> ;
     skos:altLabel "EELS"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "An analytical technique used to measure the energy loss of electrons passing through a sample. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "electron energy loss spectroscopy"@en .
 
 <https://example.org/0000047> a skos:Concept ;
     dcterms:identifier "0000047"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000069> ;
     skos:altLabel "RAMAN"@en,
         "Raman"@en,
@@ -663,12 +666,12 @@
         "raman scattering spectroscopy"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A spectroscopy technique studying the vibrational modes of molecules, by measuring the intensity and frequency of scattered by the sample of monochromatic light. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "Raman spectroscopy"@en .
 
 <https://example.org/0000048> a skos:Concept ;
     dcterms:identifier "0000048"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000070> ;
     skos:altLabel "AFM"@en,
         "SFM"@en,
@@ -677,24 +680,24 @@
         "scanning force microscopy"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A high-resolution imaging technique that measures the interaction between a sharp probe and the sample’s surface to create a three-dimensional image of the surface’s morphology.  "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "atomic force microscopy"@en .
 
 <https://example.org/0000049> a skos:Concept ;
     dcterms:identifier "0000049"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000071> ;
     skos:altLabel "DSC"@en,
         "differential scanning calorimetric (DSC) analysis"@en,
         "differential scanning calorimetric analysis"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A thermal analysis technique which compares the heat flow in a sample and a reference material under controlled applied temperature profiles. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "differential scanning calorimetry"@en .
 
 <https://example.org/0000050> a skos:Concept ;
     dcterms:identifier "0000050"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000072> ;
     skos:altLabel "TG"@en,
         "TG analysis"@en,
@@ -706,52 +709,52 @@
         "thermogravimetric (TG) analysis"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A thermal analysis technique used to measure the change of a sample’s mass under the influence of controlled applied temperature profiles."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "thermogravimetric analysis"@en .
 
 <https://example.org/0000051> a skos:Concept ;
     dcterms:identifier "0000051"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000073> ;
     skos:altLabel "NMR"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A spectroscopic technique that uses a static magnetic field and radiofrequency radiation to measure the magnetic resonance of atomic nuclei protons or electrons."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "nuclear magnetic resonance spectroscopy"@en .
 
 <https://example.org/0000052> a skos:Concept ;
     dcterms:identifier "0000052"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000074> ;
     skos:altLabel "PL"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "Light emission of lower energy photons from a sample upon its photoexcitation. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "photoluminescence"@en .
 
 <https://example.org/0000053> a skos:Concept ;
     dcterms:identifier "0000053"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000075> ;
     skos:altLabel "SEM"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "An electron microscopy technique that produces high-resolution images under high magnification of a sample's surface by assessing the secondary and back-scattered electrons produced by a focused electron beam."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "scanning electron microscopy"@en .
 
 <https://example.org/0000054> a skos:Concept ;
     dcterms:identifier "0000054"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000076> ;
     skos:altLabel "XPS"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A technique that analyzes the chemical composition of an X-ray irradiated sample by measuring the energies of the emitted electrons."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "X-ray photoelectron spectroscopy"@en .
 
 <https://example.org/0000055> a skos:Concept ;
     dcterms:identifier "0000055"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000077> ;
     skos:altLabel "X-ray analysis"@en,
         "X-ray crystallographic analysis"@en,
@@ -762,32 +765,32 @@
         "XRD"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A technique which analyses the diffraction pattern produced when X-rays are scattered by a sample bombarded by a focused electron beam."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "X-ray diffraction"@en .
 
 <https://example.org/0000056> a skos:Concept ;
     dcterms:identifier "0000056"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000078> ;
     skos:altLabel "TEM"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "Transmission electron microscopy is a technique that produces high-resolution images if the internal structure of a sample by using a beam of electrons to bombard the thin sample and measuring the intensity of the scattered transmitted electrons."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "transmission electron microscopy"@en .
 
 <https://example.org/0000057> a skos:Concept ;
     dcterms:identifier "0000057"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000079> ;
     skos:altLabel "UV-Vis"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A technique used to measure the absorption, transmission or reflectance of light by a sample in the ultraviolet and visible regions of the electromagnetic spectrum."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "ultraviolet-visible spectroscopy"@en .
 
 <https://example.org/0000058> a skos:Concept ;
     dcterms:identifier "0000058"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000080> ;
     skos:altLabel "FT-IR"@en,
         "FT-IR spectroscopy"@en,
@@ -802,85 +805,86 @@
         "Fourier-transform infrared (FTIR) absorption spectroscopy"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A spectroscopic technique used to study the vibrational modes of chemical bonds of a sample using infrared radiation."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "fourier transform infrared spectroscopy"@en .
 
 <https://example.org/0000059> a skos:Concept ;
     dcterms:identifier "0000059"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000081> ;
     skos:altLabel "BET"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "The study of physical adsorption of gas molecules on a solid surface for the calculation of the specific surface area of materials."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "Brunauer-Emmett-Teller surface area analysis"@en .
 
 <https://example.org/0000060> a skos:Concept ;
     dcterms:identifier "0000060"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000082> ;
     skos:altLabel "CV"@en,
         "cyclovoltammetry"@en ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "An electrochemical technique used to study the redox properties of a sample by measuring the current produced by an applied voltage sweep."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "cyclic voltammetry"@en .
 
 <https://example.org/0000061> a skos:Concept ;
     dcterms:identifier "0000061"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000083> ;
     skos:broader <https://example.org/0000044> ;
     skos:definition "A method used in cyclic voltammetry to determine the charge carrier concentration and the flat-band potential of an electrochemical system by measuring the capacitance as a function of applied voltage."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "Mott-Schottky analysis"@en .
 
 <https://example.org/0000076> a skos:Concept ;
     dcterms:identifier "0000076"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000098> ;
     skos:broader <https://example.org/0000065> ;
     skos:definition "The gain of electrons or a decrease in the oxidation state of a species. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000077> ;
     skos:prefLabel "reduction"@en .
 
 <https://example.org/0000080> a skos:Concept ;
     dcterms:identifier "0000080"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000130> ;
     skos:altLabel "GC"@en ;
     skos:broader <https://example.org/0000079> ;
     skos:definition "An analytical technique that separates and analyzes the components of a gas mixture by passing it though a stationary phase."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "gas chromatography"@en .
 
 <https://example.org/0000081> a skos:Concept ;
     dcterms:identifier "0000081"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000137> ;
     skos:altLabel "MS"@en ;
     skos:broader <https://example.org/0000079> ;
     skos:definition "An analytical technique which determines the mass-to-charge ratio of ions in a sample to give information about the composition of the sample."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "mass spectrometry"@en .
 
 <https://example.org/0000082> a skos:Concept ;
     dcterms:identifier "0000082"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000141> ;
     skos:altLabel "LC"@en ;
     skos:broader <https://example.org/0000079> ;
     skos:definition "A sepation technique that uses a liquid mobile phase to separate the components of a mixture based on their interactions with a stationary phase and a mobile phase. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:prefLabel "liquid chromatography"@en .
 
 <https://example.org/0000015> a skos:Concept ;
     dcterms:identifier "0000015"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000016> ;
     skos:broader <https://example.org/0000001> ;
     skos:definition "The form in which the photocatalyst is introduced to the reaction chamber. This can include e.g., powders, pellets or thin films deposited on a substrate. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000016>,
         <https://example.org/0000018> ;
@@ -888,10 +892,10 @@
 
 <https://example.org/0000023> a skos:Concept ;
     dcterms:identifier "0000023"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000024> ;
     skos:broader <https://example.org/0000018> ;
     skos:definition "The substrate onto which a (powdered) photocatalyst is deposited. Such substrates include glass surfaces (e.g., borosilicate glass or conductive glass like ITO and FTO), ceramic substrates (e.g., alumina) or metal substrates (e.g., Ti foils, stainless steel etc.) "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000024>,
         <https://example.org/0000032> ;
@@ -899,10 +903,10 @@
 
 <https://example.org/0000037> a skos:Concept ;
     dcterms:identifier "0000037"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000038> ;
     skos:broader <https://example.org/0000018> ;
     skos:definition "A thin film of the photocatalyst deposited on an appropriate for the application substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000038>,
         <https://example.org/0000039> ;
@@ -910,9 +914,9 @@
 
 <https://example.org/0000062> a skos:Concept ;
     dcterms:identifier "0000062"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000084> ;
     skos:definition "The energy state occupied by an electron in a photocatalyst. This state cab affect the electron's ability to participate in a photocatalytic reaction. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000063>,
         <https://example.org/0000064> ;
@@ -921,10 +925,10 @@
 
 <https://example.org/0000088> a skos:Concept ;
     dcterms:identifier "0000088"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000157> ;
     skos:broader <https://example.org/0000083> ;
     skos:definition "A transparent material optimized to allow the transmission of electromagnetic radiation with low reflectance and scattering. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000089>,
         <https://example.org/0000090> ;
@@ -932,10 +936,10 @@
 
 <https://example.org/0000090> a skos:Concept ;
     dcterms:identifier "0000090"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000159> ;
     skos:broader <https://example.org/0000088> ;
     skos:definition "The dimension of the optical window (diameter / thickness) allowing the incoming light to enter the reaction chamber and interact with the photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000091>,
         <https://example.org/0000092> ;
@@ -943,10 +947,10 @@
 
 <https://example.org/0000093> a skos:Concept ;
     dcterms:identifier "0000093"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000165> ;
     skos:broader <https://example.org/0000078> ;
     skos:definition "The irradiation system includes all the necessary equipment needed to perform a photocatalytic experiment. The system apart from the light source can include, filters, power units, lamp cooling devices etc."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000094>,
         <https://example.org/0000098> ;
@@ -954,10 +958,10 @@
 
 <https://example.org/0000001> a skos:Concept ;
     dcterms:identifier "0000001"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000002> ;
     skos:altLabel "photocatalytic material"@en ;
     skos:definition "A material that absorbs photons (light) of appropriate energy and initiates or accelerates a photochemical reaction, while it regenerates itself after each reaction cycle. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000002>,
         <https://example.org/0000015>,
@@ -967,10 +971,10 @@
 
 <https://example.org/0000002> a skos:Concept ;
     dcterms:identifier "0000002"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000003> ;
     skos:broader <https://example.org/0000001> ;
     skos:definition "A material with electrical conductivity between that of a conductor and an insulator."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000003>,
         <https://example.org/0000005>,
@@ -979,10 +983,10 @@
 
 <https://example.org/0000018> a skos:Concept ;
     dcterms:identifier "0000018"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000019> ;
     skos:broader <https://example.org/0000015> ;
     skos:definition "A photocatalyst introduced to the reaction chamber in the form of a thin film. To form a thin film, a (powdered) photocatalyst is deposited on a substrate (e.g., glass or metal) using an appropriate deposition technique. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000019>,
         <https://example.org/0000023>,
@@ -991,10 +995,10 @@
 
 <https://example.org/0000019> a skos:Concept ;
     dcterms:identifier "0000019"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000020> ;
     skos:broader <https://example.org/0000018> ;
     skos:definition "A technique used to deposit (immobilize) a (powdered) photocatalyst on a substate. These techniques indlude (but are not limited to): doctor blading, spin coating, spray coating, etc."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000020>,
         <https://example.org/0000021>,
@@ -1003,10 +1007,10 @@
 
 <https://example.org/0000024> a skos:Concept ;
     dcterms:identifier "0000024"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000025> ;
     skos:broader <https://example.org/0000023> ;
     skos:definition "The material that the substrate is made of. Common materials include: glass (conductive or not), ceramics and metal."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000025>,
         <https://example.org/0000026>,
@@ -1015,10 +1019,10 @@
 
 <https://example.org/0000078> a skos:Concept ;
     dcterms:identifier "0000078"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000128> ;
     skos:altLabel "reactor design; reactor engineering; photoreactor engineering"@en ;
     skos:definition "Details describing the construction, physical dimensions, and operation of the photoreactor used to perform a photocatalytic reaction."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000079>,
         <https://example.org/0000083>,
@@ -1028,10 +1032,10 @@
 
 <https://example.org/0000079> a skos:Concept ;
     dcterms:identifier "0000079"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000129> ;
     skos:broader <https://example.org/0000078> ;
     skos:definition "Spectroscopic or chromatographic methods used to qualitatively and quantitatively identify the products of the photoreaction. Such devices are usually attached to the photoreactor, or a sample is being trasfered to an identification method via another medium (e.g., gastight syringes)."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000080>,
         <https://example.org/0000081>,
@@ -1040,10 +1044,10 @@
 
 <https://example.org/0000094> a skos:Concept ;
     dcterms:identifier "0000094"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000166> ;
     skos:broader <https://example.org/0000093> ;
     skos:definition "Light source used to irradiate a photocatalyst in a reaction chamber. These include sources with various intensities, powers and wavelength ranges,  including Hg/Xe lamps, Xe lamps and LEDs. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000095>,
         <https://example.org/0000096>,
@@ -1052,11 +1056,11 @@
 
 <https://example.org/0000104> a skos:Concept ;
     dcterms:identifier "0000104"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000176> ;
     skos:altLabel "λ"@en ;
     skos:broader <https://example.org/0000098> ;
     skos:definition "The distance between two successive peaks or troughs in a wave."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000105>,
         <https://example.org/0000106>,
@@ -1065,10 +1069,10 @@
 
 <https://example.org/0000026> a skos:Concept ;
     dcterms:identifier "0000026"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000027> ;
     skos:broader <https://example.org/0000024> ;
     skos:definition "A flat surface made of glass serving as a substrate for the deposition of a photocatalyst."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000027>,
         <https://example.org/0000028>,
@@ -1078,10 +1082,10 @@
 
 <https://example.org/0000032> a skos:Concept ;
     dcterms:identifier "0000032"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000033> ;
     skos:broader <https://example.org/0000023> ;
     skos:definition "The dimensions of the substrate."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000033>,
         <https://example.org/0000034>,
@@ -1091,10 +1095,10 @@
 
 <https://example.org/0000039> a skos:Concept ;
     dcterms:identifier "0000039"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000040> ;
     skos:broader <https://example.org/0000037> ;
     skos:definition "The dimensions of the - deposited on the substrate - thin film"@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000040>,
         <https://example.org/0000041>,
@@ -1104,11 +1108,11 @@
 
 <https://example.org/0000083> a skos:Concept ;
     dcterms:identifier "0000083"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000152> ;
     skos:altLabel "photoreaction chamber"@en ;
     skos:broader <https://example.org/0000078> ;
     skos:definition "A construction inside of which the photocatalyst and the reactants coexist and the photoreaction takes place."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000084>,
         <https://example.org/0000085>,
@@ -1119,10 +1123,10 @@
 
 <https://example.org/0000098> a skos:Concept ;
     dcterms:identifier "0000098"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000170> ;
     skos:broader <https://example.org/0000093> ;
     skos:definition "Specific of roperties of the light source dictaning its operation and its adequacy in the studied photocatalytic reaction. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000099>,
         <https://example.org/0000100>,
@@ -1134,10 +1138,10 @@
 
 <https://example.org/0000005> a skos:Concept ;
     dcterms:identifier "0000005"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000006> ;
     skos:broader <https://example.org/0000002> ;
     skos:definition "Characteristic properties of a semiconductor used in the field of photocatalysis. These properties determine its performance in the studied photocatalytic application."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000006>,
         <https://example.org/0000007>,
@@ -1150,9 +1154,9 @@
 
 <https://example.org/0000065> a skos:Concept ;
     dcterms:identifier "0000065"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000087> ;
     skos:definition "A multi-step process iniatiated by the absorption of photons by a photocatalyst. This process involves various sub-processes that include the photogeneration and transfer of electron and hole pairs. "@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000066>,
         <https://example.org/0000067>,
@@ -1170,10 +1174,10 @@
 
 <https://example.org/0000044> a skos:Concept ;
     dcterms:identifier "0000044"^^xsd:token ;
-    dcterms:provenance "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     rdfs:isDefinedBy <https://w3id.org/nfdi4cat/voc4cat_0000066> ;
     skos:broader <https://example.org/0000001> ;
     skos:definition "A collection of techniques used to identify the (physico)chemical, morphological, structural, mechanical, optical and electrical properties of the syntesized photocatalysts. Characterization is performed after the synthesis of the photocatalysts to evaluate the success of the synthetic approach, but also after the completion of the evaluation of the materials in CO2 photoreduction to ensure their stability under the selected experimental parameters."@en ;
+    skos:historyNote "0000-0002-6242-2167 Nikolaos G. Moustakas created the resource"@en ;
     skos:inScheme <https://example.org> ;
     skos:narrower <https://example.org/0000045>,
         <https://example.org/0000046>,
@@ -1194,24 +1198,20 @@
         <https://example.org/0000061> ;
     skos:prefLabel "characterization"@en .
 
-<http://example.org/nfdi4cat/> a sdo:Organization ;
-    sdo:name "NFDI4Cat" ;
-    sdo:url "https://nfdi4cat.org"^^xsd:anyURI .
-
 <https://example.org> a skos:ConceptScheme ;
     dcterms:created "2023-06-29"^^xsd:date ;
     dcterms:creator <http://example.org/nfdi4cat/> ;
     dcterms:hasPart <https://example.org/0000108> ;
     dcterms:identifier "example.org"^^xsd:token ;
     dcterms:modified "2023-06-29"^^xsd:date ;
-    skos:historyNote """https://orcid.org/0000-0002-6242-2167 Nikolaos G. Moustakas,
-0000-0002-5898-1820 David Linke"""@en ;
     dcterms:publisher <http://example.org/nfdi4cat/> ;
-    owl:versionInfo "v2023-06-29" ;
+    owl:versionInfo "" ;
     skos:definition "This serves as example to demonstrate voc4cat-tool."@en ;
     skos:hasTopConcept <https://example.org/0000001>,
         <https://example.org/0000062>,
         <https://example.org/0000065>,
         <https://example.org/0000078> ;
+    skos:historyNote """https://orcid.org/0000-0002-6242-2167 Nikolaos G. Moustakas,
+0000-0002-5898-1820 David Linke"""@en ;
     skos:prefLabel "An example with terms from photocatalysis (taken from voc4Cat)"@en ;
     dcat:contactPoint "David Linke (orcid:0000-0002-5898-1820)" .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,11 @@ classmethod-decorators = [
   "pydantic.validator", "pydantic.class_validators.root_validator"
 ]
 
+[tool.mypy]
+# https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file
+# Suppress all missing import errors for all untyped libraries
+ignore_missing_imports = true
+
 [tool.codespell]
 skip = "*.xlsx,pyproject.toml,./vocabularies,./example,./tests/data,./tmp"
 # Note: words have to be lowercased for the ignore-words-list

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -8,8 +8,7 @@ from colorama import Fore, Style
 from curies import Converter
 from pydantic.error_wrappers import ValidationError
 from pyshacl.pytypes import GraphLike
-from rdflib import Graph
-from rdflib.namespace import DCAT, DCTERMS, OWL, PROV, RDF, RDFS, SKOS
+from rdflib import DCAT, DCTERMS, OWL, PROV, RDF, RDFS, SH, SKOS, Graph
 
 from voc4cat import config, models, profiles
 from voc4cat.checks import Voc4catError, validate_config_has_idrange
@@ -58,8 +57,6 @@ def validate_with_profile(
     info_list = []
     warning_list = []
     violation_list = []
-
-    from rdflib.namespace import RDF, SH
 
     for report in results_graph.subjects(RDF.type, SH.ValidationReport):
         for result in results_graph.objects(report, SH.result):
@@ -223,7 +220,12 @@ def rdf_to_excel(
                 )
             elif p == OWL.versionInfo:
                 holder["versionInfo"] = str(o)
-            elif p in [DCTERMS.source, DCTERMS.provenance, PROV.wasDerivedFrom]:
+            elif p in [
+                DCTERMS.source,
+                DCTERMS.provenance,
+                PROV.wasDerivedFrom,
+                SKOS.historyNote,
+            ]:
                 holder["provenance"] = str(o)
             elif p == SKOS.hasTopConcept:
                 holder["hasTopConcept"].append(str(o))
@@ -282,7 +284,12 @@ def rdf_to_excel(
                 holder["alt_labels"].append(str(o))
             elif p == RDFS.isDefinedBy:
                 holder["source_vocab"] = str(o)
-            elif p in [DCTERMS.source, DCTERMS.provenance, PROV.wasDerivedFrom]:
+            elif p in [
+                DCTERMS.source,
+                DCTERMS.provenance,
+                PROV.wasDerivedFrom,
+                SKOS.historyNote,
+            ]:
                 holder["provenance"] = str(o)
             elif p == SKOS.relatedMatch:
                 holder["related_match"].append(str(o))
@@ -328,7 +335,12 @@ def rdf_to_excel(
                 holder["definition"] = str(o)
             elif p == SKOS.member:
                 holder["members"].append(str(o))
-            elif p in [DCTERMS.source, DCTERMS.provenance, PROV.wasDerivedFrom]:
+            elif p in [
+                DCTERMS.source,
+                DCTERMS.provenance,
+                PROV.wasDerivedFrom,
+                SKOS.historyNote,
+            ]:
                 holder["provenance"] = str(o)
 
         models.Collection(

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -51,7 +51,7 @@ def validate_with_profile(
     # validate the RDF file
     conforms, results_graph, results_text = pyshacl.validate(
         data_graph,
-        shacl_graph=str(Path(__file__).parent / "profile" / "vocpub-pre3.0.ttl"),
+        shacl_graph=str(Path(__file__).parent / "profile" / "vocpub-4.7.ttl"),
         allow_warnings=allow_warnings,
     )
 

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -130,10 +130,12 @@ def extract_concept_scheme(
         title=sheet["B3"].value,
         description=sheet["B4"].value,
         created=sheet["B5"].value,
-        modified=sheet["B6"].value,
+        modified=(
+            sheet["B6"].value if sheet["B6"].value is not None else sheet["B5"].value
+        ),
         creator=sheet["B7"].value,
         publisher=sheet["B8"].value,
-        version=sheet["B9"].value,
+        version=sheet["B9"].value if sheet["B9"].value is not None else "",
         provenance=sheet["B10"].value,
         custodian=sheet["B11"].value,
         pid=sheet["B12"].value,

--- a/src/voc4cat/profile/specification-vocpub-4.7.md
+++ b/src/voc4cat/profile/specification-vocpub-4.7.md
@@ -1,0 +1,706 @@
+# VocPub Profile - Specification
+
+URI
+[`https://w3id.org/profile/vocpub/spec`](https://w3id.org/profile/vocpub/spec)
+
+Title
+VocPub Profile - Specification Document
+
+Definition
+This document specifies the VocPub Profile. It is to be used to inform
+people about the requirements that need to be met by data claiming to
+conform to the profile.
+
+Created
+2020-06-14
+
+Modified
+2023-11-15
+
+Version IRI
+<https://w3id.org/profile/vocpub/spec/4.6>
+
+Version Information
+4.6 Fixed sdo:historyNote-&gt;skos:historyNote bug
+
+4.5 Added suggested predicates of license & copyrightHolder
+
+4.4 Fixed versions across multiple Resources
+
+4.3 Improved validator error messages by using more named Property
+Shapes
+
+4.2: Included CONSTRUCT-based pre-validation inference in validator.
+First Git tagged version
+
+4.1: Added Requirements 2.1.10, 2.1.11 & 2.1.12 and example RDF
+
+4.0: Added a SPARQL function to allow for the inferenceing of
+`skos:inScheme` predicates, `skos:broader` / `skos:narrower` and
+`skos:topConceptOf`/`skos:hasTopConcept` pairs of inverse predicates
+
+3.3: Converted validator metadata to schema.org, enabled bibliographic
+references for Concepts, enabled DCTERMS or schema.org for many
+ConceptScheme predicates; simplified 2.1.6 from two Requirements to one;
+included `skos:topConceptOf` in 2.1.8 for Concepts at the top of the
+hierarchy; collapsed title & definition requirement pairs to single
+requirements
+
+3.2: Allowed `dcterms:provenance` and `skos:historyNote`; removed max
+restriction on `dcterms:source` & `prov:wasDerivedFrom`
+
+3.1: Changed `dcterms:provenance` to `skos:historyNote`
+
+3.0: Removed Requirement-2.3.5 (identifiers) as these are auto-generated
+in systems like VocPrez; Added Requirement-2.1.10 & 2.1.11 and sub parts
+to test for qualifiedDerivation and status of a `ConceptScheme`
+
+Creator
+[Nicholas J. Car](https://orcid.org/0000-0002-8742-7730)
+
+Publisher
+[Australian Government Linked Data Working
+Group](https://linked.data.gov.au/org/agldwg)
+
+Further metadata
+This specification is part of the *VocPub Profile*. See that profile's
+main document for License & Rights information and other metadata not
+given here.
+
+Profile URI
+[`https://w3id.org/profile/vocpub`](https://w3id.org/profile/vocpub)
+
+License
+[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+## Abstract
+
+This is the specification document of the VocPub
+[profile](https://www.w3.org/TR/dx-prof/#definitions) of
+[SKOS](https://www.w3.org/TR/skos-reference/). It defines the
+requirements that data must satisfy to be considered conformant with
+this profile.
+
+This specification document cannot be used for testing conformance of
+RDF resources to this profile: that role belongs to the *validation*
+resource within this profile:
+
+-   <https://w3id.org/profile/vocpub/validation>
+
+For the list of all resources within this profile, see the profile
+definition:
+
+-   <https://w3id.org/profile/vocpub>
+
+## Namespaces
+
+This document refers to elements of various ontologies by short codes
+using namespace prefixes. The prefixes and their corresponding
+namespaces' URIs are:
+
+dcterms
+`http://purl.org/dc/terms/`
+
+isorole
+`http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/`
+
+prof
+`http://www.w3.org/ns/dx/prof/`
+
+prov
+`http://www.w3.org/ns/prov#`
+
+reg
+`http://purl.org/linked-data/registry#>`
+
+sdo
+`https://schema.org/`
+
+skos
+`http://www.w3.org/2004/02/skos/core#`
+
+rdfs
+`http://www.w3.org/2000/01/rdf-schema#`
+
+## 1. Introduction
+
+Many organisations use the Simple Knowledge Organization System
+Reference (SKOS)<sup>[ref](#skos)</sup> to represent vocabularies in a
+form that can be read by humans and consumed by machines; that is, in
+*Semantic Web* form<sup>[ref](#semantic-web)</sup>.
+
+This profile defines a *vocabulary* as a controlled collection of
+defined terms - Concepts - that may or may not contain relationships
+between Cocnepts and relationships to Concepts in other vocabularies.
+
+This document specifies a *profile* of SKOS and for profile, the
+definition of from the *Profiles Vocabulary*<sup>[ref](#prof)</sup> is
+used. A *profile* is:
+
+A specification that constrains, extends, combines, or provides guidance
+or explanation about the usage of other specifications.
+
+Here, the *other specification* being profiled is SKOS.
+
+In the next section, this document describes how SKOS's elements must be
+presented - in certain arrangements with respect to one another and with
+certain predicates to indicate properties - to make a vocabulary that
+conforms to this profile.
+
+This specification's rules/requirements - are numbered and <span
+style="color:darkred;">indicated in red text</span>.
+
+### 1.1 Data Expansion
+
+Some SKOS elements - classes and predicates - can be inferred based on
+rules present in the SKOS model. For example, `skos:broader` and
+`skos:narrower` are inverse predicates thus if I have
+`<A> skos:broader <B>`, I can infer `<B> skos:narrower <A>`.
+
+This profile allows data to be supplied in a minimalist form that is not
+conformant to this specification until a series of calculations, based
+on certain SKOS rules, are carried out on it through a process known as
+data *expansion*.
+
+The particular rules that may be applied to data before validation with
+this profile's validator are given in the table below. These rules are
+enacted by the application of a series of
+SPARQL<sup>[ref](#sparql)</sup> queries to the data, all of which are
+packaged up inside a SHACL<sup>[ref](#shacl)</sup> file in this
+profile's repository.
+
+<table class="bordered">
+<colgroup>
+<col style="width: 33%" />
+<col style="width: 33%" />
+<col style="width: 33%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Rule</th>
+<th>Description</th>
+<th>SPARQL Query</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>hasTopConcept</td>
+<td>Calculate <code>skos:hasTopConcept</code> as the inverse to
+<code>skos:topConceptOf</code></td>
+<td><pre><code>CONSTRUCT {
+    $this skos:hasTopConcept ?c .
+}
+WHERE {
+    ?c skos:topConceptOf $this .
+}</code></pre></td>
+</tr>
+<tr class="even">
+<td>topConceptOf</td>
+<td>Calculate <code>skos:topConceptOf</code> as the inverse to
+<code>skos:hasTopConcept</code></td>
+<td><pre><code>CONSTRUCT {
+    $this skos:topConceptOf ?cs .
+}
+WHERE {
+    ?cs skos:hasTopConcept $this .
+}</code></pre></td>
+</tr>
+<tr class="odd">
+<td>broader</td>
+<td>Calculate <code>skos:broader</code> as the inverse to
+<code>skos:narrower</code></td>
+<td><pre><code>CONSTRUCT {
+    $this skos:broader ?n .
+}
+WHERE {
+    ?n skos:narrower $this .
+}</code></pre></td>
+</tr>
+<tr class="even">
+<td>narrower</td>
+<td>Calculate <code>skos:narrower</code> as the inverse to
+<code>skos:broader</code></td>
+<td><pre><code>CONSTRUCT {
+    $this skos:narrower ?b .
+}
+WHERE {
+    ?b skos:broader $this .
+}</code></pre></td>
+</tr>
+<tr class="odd">
+<td>inScheme</td>
+<td>Calculate <code>skos:inScheme</code> for all Concepts, based on
+their linking to a Concept Scheme via
+<code>skos:broader/skos:topConceptOf</code> property path</td>
+<td><pre><code>CONSTRUCT {
+    $this skos:inScheme ?cs .
+}
+WHERE {
+    $this skos:broader*/skos:topConceptOf ?cs .
+}</code></pre></td>
+</tr>
+<tr class="even">
+<td>Concept provenance</td>
+<td>Infer provenance predicates for a Concept when they don't have their
+own but their containing Concept Scheme does</td>
+<td><pre><code>CONSTRUCT {
+    $this ?p ?o3
+}
+WHERE {
+    $this skos:inScheme ?cs .
+
+    VALUES ?p {
+        prov:wasDerivedFrom
+        skos:historyNote
+        sdo:citation
+        dcterms:source
+        dcterms:provenance
+    }
+
+    ?cs ?p ?o .
+
+    OPTIONAL {
+        $this ?p ?o2 .
+    }
+
+    BIND (COALESCE(?o2, ?o) AS ?o3)
+}</code></pre></td>
+</tr>
+</tbody>
+</table>
+
+Application of these rules will allow a Concept supplied without any
+provenance predicates to be calculated from its containing Concept
+Scheme, thus satisfying Requirement 2.3.4.
+
+The SHACL file containing all the expansion queries is available at:
+
+-   <https://w3id.org/profile/vocpub/expander>
+
+A Python script able to execute the expansion rule on RDF data before
+validation is available at:
+
+-   <https://w3id.org/profile/vocpub/validate>
+
+### 1.2 Dependencies
+
+To characterise vocabularies according to the mandatory and suggested
+Requirements of this Profile, several other vocabularies will need to be
+used. This profile is therefore dependent on those vocabularies. For
+this reason, copies of these vocabularies are maintained within the
+repository of this profile and are accessible as per the details table
+below.
+
+<table class="bordered">
+<thead>
+<tr class="header">
+<th>Vocabulary</th>
+<th>Description</th>
+<th>Where used</th>
+<th>Local Copy</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><a href="https://data.idnau.org/pid/vocab/idn-role-codes">IDN Role
+Codes</a></td>
+<td>he Indigenous Data Network's vocabulary of the types of roles Agents
+- People and Organisations - play in relation to data</td>
+<td>For the predicate <code>prov:hadRole</code>, applied to an
+<code>Attribution</code> indicated by a
+<code>prov:qualifiedAttribution</code> predicate for a Concept
+Scheme</td>
+<td><a
+href="https://data.idnau.org/pid/vocab/idn-role-codes">https://data.idnau.org/pid/vocab/idn-role-codes</a></td>
+</tr>
+<tr class="even">
+<td><a href="https://linked.data.gov.au/def/reg-statuses">Registry
+Statuses</a></td>
+<td>The registration statuses of items in a Register, as per
+ISO19135</td>
+<td>For the suggested vocabulary predicate <code>reg:status</code>, as
+per <span style="color:darkred;">Requirement 2.1.11</span></td>
+<td><a
+href="https://linked.data.gov.au/def/reg-statuses">https://linked.data.gov.au/def/reg-statuses</a></td>
+</tr>
+<tr class="odd">
+<td><a href="https://linked.data.gov.au/def/vocdermods">Vocab Derivation
+Modes</a></td>
+<td>The modes by which one vocabulary may derive from another</td>
+<td>For the suggested vocabulary predicate
+<code>prov:qualifiedDerivation</code>, as per <span
+style="color:darkred;">Requirement 2.1.12</span></td>
+<td><a
+href="https://linked.data.gov.au/def/vocdermods">https://linked.data.gov.au/def/vocdermods</a></td>
+</tr>
+</tbody>
+</table>
+
+## 2. Elements & Requirements
+
+### 2.1 Vocabulary
+
+This profile identifies Semantic Web objects with URI-based persistent
+identifiers. For this reason:
+
+<a href="#2.1.1" id="2.1.1" class="frag">§</a> 2.1.1 Each vocabulary
+*MUST* be identified by a IRI
+
+As per the *SKOS Primer*<sup>[ref](#skos-primer)</sup>, a document
+guiding the use of SKOS:
+
+concepts usually come in carefully compiled vocabularies, such as
+thesauri or classification schemes. SKOS offers the means of
+representing such KOSs using the `skos:ConceptScheme` class.
+
+For this reason, this profile requires that:
+
+<a href="#2.1.2" id="2.1.2" class="frag">§</a> 2.1.2 Each vocabulary
+*MUST* be presented as a single Concept Scheme object
+
+For ease of data management:
+
+<a href="#2.1.3" id="2.1.3" class="frag">§</a> 2.1.3 Each vocabulary
+*MUST* be presented in a single RDF file which does not contain
+information other than that which is directly part of the vocabulary
+
+To ensure vocabularies can be catalogued effectively and governed:
+
+<a href="#2.1.4" id="2.1.4" class="frag">§</a> 2.1.4 Each vocabulary
+*MUST* have exactly one title and at least one definition indicated
+using the `skos:prefLabel` and the `skos:definition` predicates
+respectively that must give textual literal values. Only one definition
+per language is allowed
+
+**NOTE**: Unlike the general directions for the use of SKOS (the [SKOS
+"Primer"](https://www.w3.org/TR/skos-primer/)) labels in multiple
+languages should be indicated with `skos:altLabel` predicates, not all
+with `skos:prefLabel`, i.e. there should only ever be one
+`skos:prefLabel` value. If multiple definitions are given, the one in
+the language of the label is considered primary.
+
+<a href="#2.1.5" id="2.1.5" class="frag">§</a> 2.1.5 Each vocabulary
+*MUST* have exactly one created date and exactly one modified date
+indicated using the `sdo:dateCreated` and `sdo:dateModified` or
+`dcterms:created` and `dcterms:modified` predicates respectively that
+must be either an `xsd:date`, `xsd:dateTime` or `xsd:dateTimeStamp`
+literal value
+
+<a href="#2.1.6" id="2.1.6" class="frag">§</a> 2.1.6 Each vocabulary
+*MUST* have at least one creator, indicated using `sdo:creator` or
+`dcterms:creator` predicate and exactly one publisher, indicated using
+`sdo:publisher` or `dcterms:publisher`, all of which MUST be IRIs
+indicating instances of `sdo:Person`, or `sdo:Organization`. A
+`prov:qualifiedAttribution` predicate indicating an Agent with the
+`prov:hadRole` predicate indicating the value `isorole:originator` or
+`isorole:publisher` may be used instead of `sdo:creator` &
+`sdo:publisher`, respectively
+
+To be able to link SKOS vocabularies to their non-vocabulary source
+information:
+
+<a href="#2.1.7" id="2.1.7" class="frag">§</a> 2.1.7 The origins of a
+Concept Scheme *MUST* be indicated by at least one of the following
+predicates: `skos:historyNote`, `sdo:citation`, `prov:wasDerivedFrom`.
+`dcterms:source` *MAY* be used instead of `sdo:citation` and
+`dcterms:provenance` *MAY* be used instead of `skos:historyNote` but the
+schema.org and SKOS predicates are preferred.
+
+If a vocabulary is based on another Semantic Web resource, such as an
+ontology or another vocabulary, `prov:wasDerivedFrom` should be used to
+indicate that resource's IRI. If the vocabulary is based on a resource
+that is identified by a IRI but which is not a Semantic Web resource,
+`sdo:citation` should be used to indicate the resource's IRI with the
+`xsd:anyURI` datatype. If the vocabulary is based on something which
+cannot be identified by IRI, a statement about the vocabulary's origins
+should be given in a literal value indicated with the `skos:historyNote`
+predicate. If the vocabulary is not based on any other resource or
+source of information, i.e. this vocabulary is its only expression, this
+should be communicated by use of the `skos:historyNote` indicating the
+phrase "This vocabulary is expressed for the first time here".
+
+*The use of `dcterms:source` & `dcterms:provenance` is to maintain
+compatibility with previous versions of VocPub only and may eventually
+be disallowed.*
+
+To ensure that all the terms within a vocabulary are linked to the main
+vocabulary object, the Concept Scheme:
+
+<a href="#2.1.8" id="2.1.8" class="frag">§</a> 2.1.8 All Concept
+instances within a Concept Scheme *MUST* be contained in a single term
+hierarchy using `skos:hasTopConcept` / `skos:topConceptOf` predicates
+indicating the broadest Concepts in the vocabulary and then
+`skos:broader` and/or `skos:narrower` predicates for all non-broadest
+Concepts in a hierarchy that contains no cycles.
+
+To unambiguously link the term hierarchy within a vocabulary to the
+vocabulary itself:
+
+<a href="#2.1.9" id="2.1.9" class="frag">§</a> 2.1.9 Each vocabulary's
+Concept Scheme *MUST* link to at least one Concept within the vocabulary
+with the `skos:hasTopConcept` predicate
+
+To communicate the *Registry Status* of the vocabulary:
+
+<a href="#2.1.10" id="2.1.10" class="frag">§</a> 2.1.10 The status of
+the vocabulary as a whole, according to the Registry Status
+standard<sup>[ref](#iso19135)</sup>, *SHOULD* be given with the
+predicate `reg:status` indicating a Concept from the *Registry Statuses*
+vocabulary (<https://linked.data.gov.au/def/reg-statuses>).
+
+To indicate whether and if so how this vocabulary has been derived from
+another vocabulary:
+
+<a href="#2.1.11" id="2.1.11" class="frag">§</a> 2.1.11 The derivation
+status of the vocabulary *SHOULD* be given should be given with the
+predicate `prov:qualifiedDerivation` indicating a Blank Node that
+contains the predicated `prov:entity`, to indicate the vocabulary
+derived from and `prov:hadRole` to indicate the mode of derivation which
+*SHOULD* be taken from the *Vocabulary Derivation Modes* vocabulary
+(<https://linked.data.gov.au/def/vocdermods>).
+
+Example data for a vocabulary indicating that it is an extension to
+another vocabulary using the mechanism defined in Requirement 2.1.2 is:
+
+    # Vocab X is derived from Vocab Y and is an extension of it
+    <http://example.com/vocab/x>
+        a skos:ConceptScheme ;
+        skos:prefLabel "Vocab X"@en ;
+        ...
+        prov:qualifiedDerivation [
+            prov:entity <http://example.com/vocab/y> ;  # Vocab Y
+            prov:hadRole <https://linked.data.gov.au/def/vocdermods/extension> ;
+        ] ;
+    .
+
+To high-level theming of a vocabulary:
+
+<a href="#2.1.12" id="2.1.12" class="frag">§</a> 2.1.12 High-level
+theming of a vocabulary *SHOULD* be given using the `sdo:keywords`
+predicate indicating Concepts from another vocabulary. Alternatively,
+`dcat:theme` *MAY* be used. Text literal values for either predicate
+*SHOULD NOT* be used.
+
+To indicate license, copyright:
+
+<a href="#2.1.13" id="2.1.13" class="frag">§</a> 2.1.13 Any licence
+pertaining to the reuse of a vocabulary's content *SHOULD* be given
+using the `sdo:license` predicate preferentially indicating the IRI of a
+license if in RDF form or a literal URL (datatype `xsd:anyURI`) if
+online but not in RDF form. If the licence is expressed in test, a
+literal text field may be indicated.
+
+<a href="#2.1.14" id="2.1.14" class="frag">§</a> 2.1.14 The copyright
+holder for the vocabulary *SHOULD* be given using the
+`sdo:copyrightHolder` predicate preferentially indicating the IRI of an
+Agent or a Blank Node instance of an Agent containing details as per
+Agent requirements. A `prov:qualifiedAttribution` predicate indicating
+an Agent with the `prov:hadRole` predicate indicating the value
+`isorole:rightsHolder` may be used instead of `sdo:copyrightHolder`.
+
+### 2.2 Collection
+
+From the SKOS Primer<sup>[ref](#skos-primer)</sup>:
+
+SKOS makes it possible to define meaningful groupings or "collections"
+of concepts. Collections may contain Concepts defined in any vocabulary,
+not just the one the Collection itself is defined in.
+
+To ensure that Collection instances are identifiable and their meaning
+isn't obscure or lost:
+
+<a href="#2.2.1" id="2.2.1" class="frag">§</a> 2.2.1 Each Collection
+*MUST* have exactly one title and at least one definition indicated
+using the `skos:prefLabel` and the `skos:definition` predicates
+respectively that must give textual literal values. Only one definition
+per language is allowed
+
+**NOTE**: Unlike the general directions for the use of SKOS (the [SKOS
+"Primer"](https://www.w3.org/TR/skos-primer/)) labels in multiple
+languages should be indicated with `skos:altLabel` predicates, not all
+with `skos:prefLabel`, i.e. there should only ever be one
+`skos:prefLabel` value. If multiple definitions are given, the one in
+the language of the label is considered primary.
+
+If a Collection's grouping of Concepts is derived from an existing
+resource that is different from the ConceptScheme it is defined within:
+
+<a href="#2.2.2" id="2.2.2" class="frag">§</a> 2.2.2 The origins of a
+Collection, if different from its containing Concept Scheme, *SHOULD* be
+indicated by at least one of the following predicates:
+`skos:historyNote`, `sdo:citation`, `prov:wasDerivedFrom`.
+`dcterms:source` *MAY* be used instead of `sdo:citation` and
+`dcterms:provenance` *MAY* be used instead of `skos:historyNote` but the
+schema.org and SKOS predicates are preferred.
+
+*For compatibility with previous versions of this Specification,
+`dcterms:provenance` MAY be used instead of `skos:historyNote` but the
+latter is the preferred predicate.*
+
+To help list Collections within vocabularies:
+
+<a href="#2.2.3" id="2.2.3" class="frag">§</a> 2.2.3 A Collection exists
+within a vocabulary *SHOULD* indicate that it is within the vocabulary
+by use of the `skos:inScheme` predicate. If it is defined for the first
+time in the vocabulary, it should also indicate this with the
+`rdfs:isDefinedBy` predicate
+
+To ensure that a Collection isn't empty:
+
+<a href="#2.2.4" id="2.2.4" class="frag">§</a> 2.2.4 A Collection *MUST*
+indicate at least one Concept instance that is within the collection
+with use of the `skos:member` predicate. The Concept need not be defined
+by the Concept Scheme that defines the Collection
+
+### 2.3 Concept
+
+From the SKOS Primer<sup>[ref](#skos-primer)</sup>:
+
+The fundamental element of the SKOS vocabulary is the concept. Concepts
+are the units of thought — ideas, meanings, or (categories of) objects
+and events—which underlie many knowledge organization systems
+
+Vocabularies conforming to this profile must present at least one
+Concept within the vocabulary file and, as per requirements in Section
+2.1, at least once Concept must be indicated as the top concept of the
+vocabulary.
+
+To ensure that Concept instances are identifiable and their meaning
+isn't obscure or lost:
+
+<a href="#2.3.1" id="2.3.1" class="frag">§</a> 2.3.1 Each Concept *MUST*
+have exactly one title and at least one definition indicated using the
+`skos:prefLabel` and the `skos:definition` predicates respectively that
+must give textual literal values. Only one definition per language is
+allowed
+
+**NOTE**: Unlike the general directions for the use of SKOS (the [SKOS
+"Primer"](https://www.w3.org/TR/skos-primer/)) labels in multiple
+languages should be indicated with `skos:altLabel` predicates, not all
+with `skos:prefLabel`, i.e. there should only ever be one
+`skos:prefLabel` value. If multiple definitions are given, the one in
+the language of the label is considered primary.
+
+To ensure that every Concept is linked to the vocabulary that defines
+it:
+
+<a href="#2.3.2" id="2.3.2" class="frag">§</a> 2.3.2 Each Concept in a
+vocabulary *MAY* indicate the vocabulary that defines it by use of the
+`rdfs:isDefinedBy` predicate indicating a Concept Scheme instance. If no
+such predicate is given, the Concept Scheme in the file that a Concept
+is provided in is understood to be the defining Concept Scheme
+
+Note that the vocabulary that defines a Concept does not have to be the
+vocabulary in the file being validated. This is to allow for Concept
+instance reuse across multiple vocabularies.
+
+Since a Concept may be used in more than one vocabulary:
+
+<a href="#2.3.3" id="2.3.3" class="frag">§</a> 2.3.3 Each Concept in a
+vocabulary *MUST* indicate that it appears within that vocabulary's
+hierarchy of Concepts either directly by use of the `skos:topConceptOf`
+predicate indicating the vocabulary or indirectly by use of one or more
+`skos:broader` / `skos:narrower` predicates placing the Concept within a
+chain of other Concepts, the top concept of which uses the
+`skos:topConceptOf` predicate to indicate the vocabulary.
+
+If a Concept is derived from an existing resource and that derivation is
+not already covered by source information for the vocabulary that it is
+within:
+
+<a href="#2.3.4" id="2.3.4" class="frag">§</a> 2.3.4 The origins of a
+Concept, if different from its containing Concept Scheme, *SHOULD* be
+indicated by at least one of the following predicates:
+`skos:historyNote`, `sdo:citation`, `dcterms:source` or
+`prov:wasDerivedFrom` or `dcterms:provenance`.
+
+If a Concept is based on another Semantic Web resource, such as another
+Concept or other defined object, `prov:wasDerivedFrom` should be used to
+indicate that resource's IRI. If the Concept is based on a resource that
+is identified by a IRI but which is not a Semantic Web resource,
+`dcterms:source` should be used to indicate the resource's IRI. If the
+vocabulary is based on something which cannot be identified by IRI, a
+statement about the vocabulary's origins should be given in a literal
+value indicated with the `skos:historyNote` predicate. If the vocabulary
+is not based on any other resource or source of information, i.e. this
+vocabulary is its only expression, this should be communicated by use of
+the `skos:historyNote` indicating the phrase "This vocabulary is
+expressed for the first time here".
+
+### 2.4 Agent
+
+To be consistent with other Semantic Web representations of Agents,
+vocabularies' associated Agents, creator & publisher must be certain
+typed RDF values:
+
+<a href="#2.4.1" id="2.4.1" class="frag">§</a> 2.4.1 Each Agent
+associated with a vocabulary *MUST* be typed as an `sdo:Person` or
+`sdo:Organization`
+
+To ensure human readability and association of Agents with their
+non-Semantic Web (real world) form:
+
+<a href="#2.4.2" id="2.4.2" class="frag">§</a> 2.4.2 Each Agent *MUST*
+give exactly one name with the `sdo:name` predicate indicating a literal
+text value
+
+To ensure that Agents are linked to non-Semantic Web forms of
+identification:
+
+<a href="#2.4.3" id="2.4.3" class="frag">§</a> 2.4.3 Each Agent *MUST*
+indicate either a `sdo:url` (for organizations) or a `sdo:email` (for
+people) predicate with a URL or email value
+
+To link to Agent registers using non-Semantic Web identifiers for
+Agents:
+
+<a href="#2.4.4" id="2.4.4" class="frag">§</a> 2.4.4 Each Agent *SHOULD*
+indicate any non-Semantic Web identifiers for Agents with the
+`sdo:identifier` predicate with literal identifier values,
+preferentially with custom data types that define the form of the
+identifier.
+
+**NOTE**: This method of providing identifiers with specialised
+datatypes is the same as that specified for `skos:notation` values in
+the [SKOS Primer](https://www.w3.org/TR/skos-primer/#secnotations).
+
+## 3. References
+
+<span id="prof"></span>PROF
+Rob Atkinson; Nicholas J. Car (eds.). *The Profiles Vocabulary*. 18
+December 2019. W3C Working Group Note. URL:
+<https://www.w3.org/TR/dx-prof/>
+
+<span id="iso19135"></span>ISO 19135-1:2015
+International Organization for Standardization *ISO 19135-1:2015 -
+Geographic information - Procedures for item registration - Part 1:
+Fundamentals*. 2015. ISO Standard. URL:
+<https://www.iso.org/standard/54721.html>
+
+<span id="owl"></span>OWL
+W3C OWL Working Group (eds.). *OWL 2 Web Ontology Language Document
+Overview (Second Edition)*. 11 December 2012. W3C Recommendation. URL:
+<https://www.w3.org/TR/owl2-overview/>
+
+<span id="shacl"></span>SHACL
+World Wide Web Consortium. *Shapes Constraint Language (SHACL)* 20
+July 2017. W3C Recommendation. URL: <https://www.w3.org/TR/shacl/>
+
+<span id="skos"></span>SKOS
+Alistair Miles; Sean Bechhofer (eds.). *SKOS Simple Knowledge
+Organization System Reference*. 18 August 2009. W3C Recommendation. URL:
+<https://www.w3.org/TR/skos-reference/>
+
+<span id="skos-primer"></span>SKOS Primer
+Antoine Isaac; Ed Summers (eds.). *SKOS Simple Knowledge Organization
+System Primer*. 18 August 2009. W3C Note. URL:
+<https://www.w3.org/TR/skos-primer/>
+
+<span id="semantic-web"></span>Semantic Web
+World Wide Web Consortium. *Semantic Web* 2015. Web Page. URL:
+<https://www.w3.org/standards/semanticweb/>, accessed 2020-06-14
+
+<span id="sparql"></span>SPARQL
+World Wide Web Consortium. *SPARQL 1.2 Query Language* 29
+September 2023. W3C Working Draft. URL:
+<https://www.w3.org/TR/sparql12-query/>

--- a/src/voc4cat/profile/vocpub-4.7.ttl
+++ b/src/voc4cat/profile/vocpub-4.7.ttl
@@ -1,0 +1,548 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX reg: <http://purl.org/linked-data/registry#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sdo: <https://schema.org/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+BASE <https://w3id.org/profile/vocpub/validator/>
+
+
+<https://w3id.org/profile/vocpub/validator>
+    a owl:Ontology ;
+    sdo:name "VocPub Validator"@en ;
+    sdo:definition "SHACL validator for the VocPub Profile"@en ;
+    sdo:creator <https://orcid.org/0000-0002-8742-7730> ;
+    sdo:publisher <https://linked.data.gov.au/org/agldwg> ;
+    sdo:dateCreated "2020-06-14"^^xsd:date ;
+    sdo:dateModified "2023-12-05"^^xsd:date ;
+    owl:versionIRI <https://w3id.org/profile/vocpub/validator/4.7> ;
+    owl:versionInfo """4.7 Fixed modified date alternate path listing bug
+
+4.6 Fixed sdo:historyNote->skos:historyNote bug
+
+4.5 Added suggested predicates of license & copyrightHolder
+
+4.4 Fixed versions across multiple Resources
+
+4.3 Improved validator error messages by using more named Property Shapes
+
+4.2: Included CONSTRUCT-based pre-validation inference in validator. First Git tagged version
+
+4.1: Added Requirements 2.1.10, 2.1.11 & 2.1.12 and example RDF
+
+4.0: Added a SPARQL function to allow for the inferenceing of skos:inScheme predicates, skos:broader / skos:narrower and skos:topConceptOf/skos:hasTopConcept pairs of inverse predicates
+
+3.3: Converted validator metadata to schema.org, enabled bibliographic references for Concepts, enabled DCTERMS or schema.org for many ConceptScheme predicates; simplified 2.1.6 from two Requirements to one; included skos:topConceptOf in 2.1.8 for Concepts at the top of the hierarchy; collapsed title & definition requirement pairs to single requirements
+
+3.2: Allowed dcterms:provenance and skos:historyNote; removed max restriction on dcterms:source & prov:wasDerivedFrom
+
+3.1: Changed dcterms:provenance to skos:historyNote
+
+3.0: Removed Requirement-2.3.5 (identifiers) as these are auto-generated in systems like VocPrez; Added Requirement-2.1.10 & 2.1.11 and sub parts to test for qualifiedDerivation and status of a ConceptScheme""" ;
+.
+
+<https://linked.data.gov.au/org/agldwg>
+    a sdo:Organization ;
+    sdo:name "Australian Government Linked Data Working Group" ;
+    sdo:url "https://www.linked.data.gov.au"^^xsd:anyURI ;
+.
+
+<https://orcid.org/0000-0002-8742-7730>
+    a sdo:Person ;
+    sdo:name "Nicholas J. Car" ;
+    sdo:email "nicholas.car@anu.edu.au"^^xsd:anyURI ;
+    sdo:identifier "https://orcid.org/0000-0002-8742-7730"^^xsd:anyURI ;
+.
+
+#
+#   Node Shapes
+#
+
+#
+#   ConceptScheme
+#
+# Requirement-2.1.1 so far un-implemented in SHACL
+
+<Requirement-2.1.2+3>
+    a sh:NodeShape ;
+    sh:targetNode skos:ConceptScheme ;
+    sh:property <ConceptSchemeType> ;
+.
+
+<Requirement-2.1.4>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+	sh:message "Requirement 2.1.4 Each vocabulary MUST have exactly one title and at least one definition indicated using the skos:prefLabel and the skos:definition predicates respectively that must give textual literal values. Only one definition per language is allowed" ;
+    sh:property
+        <prefLabel> ,
+        <definition> ;
+.
+
+<Requirement-2.1.5>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+	sh:message "Requirement 2.1.5 Each vocabulary MUST have exactly one created date and exactly one modified date indicated using the sdo:dateCreated and sdo:dateModified or dcterms:created and dcterms:modified predicates respectively that must be either an xsd:date, xsd:dateTime or xsd:dateTimeStamp literal value" ;
+	sh:property
+        <created> ,
+        <modified> ;
+.
+
+<Requirement-2.1.6>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+	sh:message "Requirement 2.1.6 Each vocabulary MUST have at least one creator, indicated using sdo:creator or dcterms:creator predicate and exactly one publisher, indicated using sdo:publisher or dcterms:publisher, all of which MUST be IRIs indicating instances of sdo:Person, or sdo:Organization" ;
+	sh:property
+        <creator> ,
+        <publisher> ;
+.
+
+<Requirement-2.1.7>
+    a sh:NodeShape ;
+    sh:targetClass skos:ConceptScheme ;
+    sh:message "Requirement 2.1.7 The origins of a Concept Scheme MUST be indicated by at least one of the following predicates: skos:historyNote, sdo:citation, prov:wasDerivedFrom. dcterms:source MAY be used instead of sdo:citation and dcterms:provenance MAY be used instead of skos:historyNote but the schema.org and SKOS predicates are preferred" ;
+    sh:or (
+        <provenance-properties-01>
+        <provenance-properties-02>
+        <provenance-properties-03>
+        <provenance-properties-04>
+        <provenance-properties-05>
+    ) ;
+.
+
+<Requirement-2.1.8>
+	a sh:NodeShape ;
+	sh:targetClass skos:Concept ;
+    sh:property <minConcepts> ;
+.
+
+<Requirement-2.1.9>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+    sh:property [
+        sh:message "Requirement 2.1.9 Each vocabulary's Concept Scheme MUST link to at least one Concept within the vocabulary with the skos:hasTopConcept predicate" ;
+        sh:path skos:hasTopConcept ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+<Requirement-2.1.10>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+    sh:property [
+        sh:message "Requirement 2.1.10 The status of the vocabulary as a whole, according to the Registry Status standard, SHOULD be given with the predicate reg:status indicating a Concept from the Registry Statuses vocabulary (https://linked.data.gov.au/def/reg-statuses)" ;
+        sh:path reg:status ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.1.11>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+    sh:property <qualifiedDerivation> ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.1.11b>
+	a sh:NodeShape ;
+	sh:targetObjectsOf prov:qualifiedDerivation ;
+    sh:property <qualifiedDerivation-entity> ;
+.
+
+<Requirement-2.1.11c>
+	a sh:NodeShape ;
+	sh:targetObjectsOf prov:qualifiedDerivation ;
+    sh:property <qualifiedDerivation-hadRole> ;
+.
+
+<Requirement-2.1.12>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+    sh:property <theming> ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.1.13>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+    sh:property <license> ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.1.14>
+	a sh:NodeShape ;
+	sh:targetClass skos:ConceptScheme ;
+    sh:property <copyrightHolder> ;
+    sh:severity sh:Warning ;
+.
+
+#
+#   Collections
+#
+<Requirement-2.2.1>
+	a sh:NodeShape ;
+	sh:targetClass skos:Collection ;
+    sh:message "Requirement 2.1.4 Each Collection MUST have exactly one title and at least one definition indicated using the skos:prefLabel and the skos:definition predicates respectively that must give textual literal values. Only one definition per language is allowed" ;
+    sh:property
+        <prefLabel> ,
+        <definition> ;
+.
+
+<Requirement-2.2.2>
+    a sh:NodeShape ;
+    sh:message "Requirement 2.2.2 The origins of a Collection, if different from its containing Concept Scheme, SHOULD be indicated by at least one of the following predicates: skos:historyNote, sdo:citation, prov:wasDerivedFrom. dcterms:source MAY be used instead of sdo:citation and dcterms:provenance MAY be used instead of skos:historyNote but the schema.org and SKOS predicates are preferred" ;
+    sh:targetClass skos:Collection ;
+    sh:or (
+        <provenance-properties-01>
+        <provenance-properties-02>
+        <provenance-properties-03>
+        <provenance-properties-04>
+        <provenance-properties-05>
+    ) ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.2.3>
+    a sh:NodeShape ;
+    sh:targetClass skos:Collection ;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Requirement 2.2.3 A Collection exists within a vocabulary SHOULD indicate that it is within the vocabulary by use of the skos:inScheme predicate. If it is defined for the first time in the vocabulary, it should also indicate this with the rdfs:isDefinedBy predicate. This message is about skos:inScheme"
+    ] ,
+    [
+        sh:path rdfs:isDefinedBy ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Requirement 2.2.3 A Collection exists within a vocabulary SHOULD indicate that it is within the vocabulary by use of the skos:inScheme predicate. If it is defined for the first time in the vocabulary, it should also indicate this with the rdfs:isDefinedBy predicate. This message is about rdfs:isDefinedBy"
+    ] ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.2.4>
+    a sh:NodeShape ;
+    sh:targetClass skos:Collection ;
+    sh:property [
+        sh:path skos:member ;
+        sh:minCount 1 ;
+        sh:message "Requirement 2.2.4 A Collection MUST indicate at least one Concept instance that is within the collection with use of the skos:member predicate. The Concept need not be defined by the Concept Scheme that defines the Collection" ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+#
+#   Concept
+#
+<Requirement-2.2.1>
+	a sh:NodeShape ;
+	sh:targetClass skos:Concept ;
+    sh:message "Requirement 2.1.4 Each Concept MUST have exactly one title and at least one definition indicated using the skos:prefLabel and the skos:definition predicates respectively that must give textual literal values. Only one definition per language is allowed" ;
+    sh:property
+        <prefLabel> ,
+        <definition> ;
+.
+
+<Requirement-2.3.2>
+	a sh:NodeShape ;
+	sh:targetClass skos:Concept ;
+    sh:message "Requirement 2.3.2 Each Concept in a vocabulary MAY indicate the vocabulary that defines it by use of the rdfs:isDefinedBy predicate indicating a Concept Scheme instance. If no such predicate is given, the Concept Scheme in the file that a Concept is provided in is understood to be the defining Concept Scheme" ;
+    sh:property [
+        sh:path rdfs:isDefinedBy ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+    sh:severity sh:Warning ;
+.
+
+<Requirement-2.3.3>
+	a sh:NodeShape ;
+	sh:targetClass skos:Concept ;
+    sh:property <inScheme> ;
+.
+
+<Requirement-2.3.4>
+    a sh:NodeShape ;
+    sh:targetClass skos:Concept ;
+    sh:message "Requirement 2.2.2 The origins of a Concept, if different from its containing Concept Scheme, SHOULD be indicated by at least one of the following predicates: skos:historyNote, sdo:citation, prov:wasDerivedFrom. dcterms:source MAY be used instead of sdo:citation and dcterms:provenance MAY be used instead of skos:historyNote but the schema.org and SKOS predicates are preferred" ;
+    sh:or (
+        <provenance-properties-01>
+        <provenance-properties-02>
+        <provenance-properties-03>
+        <provenance-properties-04>
+        <provenance-properties-05>
+    ) ;
+    sh:severity sh:Warning ;
+.
+
+#
+#   Agent
+#
+<Requirement-2.4.2>
+	a sh:NodeShape ;
+	sh:targetClass sdo:Organization , sdo:Person ;
+    sh:property [
+        sh:path sdo:name ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:message "Requirement 2.4.2 Each Agent MUST give exactly one name with the sdo:name predicate indicating a literal text value" ;
+    ] ;
+.
+
+<Requirement-2.4.3a>
+	a sh:NodeShape ;
+	sh:targetClass sdo:Organization ;
+    sh:property [
+        sh:path sdo:url ;
+        sh:minCount 1 ;
+        sh:datatype xsd:anyURI ;
+        sh:message "Requirement 2.4.3 Each Agent MUST indicate either a sdo:url (for organizations) or a sdo:email (for people) predicate with a URL or email value. This error message is for Organizations" ;
+    ] ;
+
+.
+
+<Requirement-2.4.3b>
+	a sh:NodeShape ;
+	sh:targetClass sdo:Person ;
+    sh:property [
+        sh:path sdo:email ;
+        sh:minCount 1 ;
+        sh:datatype xsd:anyURI ;
+        sh:message "Requirement 2.4.3 Each Agent MUST indicate either a sdo:url (for organizations) or a sdo:email (for people) predicate with a URL or email value. This error message is for Persons"
+    ] ;
+.
+
+
+#
+#   Property Shapes
+#
+<ConceptSchemeType>
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:message "Requirement 2.1.2 Each vocabulary MUST be presented as a single Concept Scheme object & Requirement 2.1.3 Each vocabulary MUST be presented in a single RDF file which does not contain information other than that which is directly part of the vocabulary" ;
+.
+
+<prefLabel>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.4, 2.2.1 or 2.3.1 Each vocabulary, Collection or Concept MUST have exactly one title and at least one definition indicated using the skos:prefLabel and the skos:definition predicates respectively that must give textual literal values. Only one definition per language is allowed" ;
+    sh:path skos:prefLabel ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:uniqueLang true ;
+    sh:or (
+        [ sh:datatype xsd:string ]
+        [ sh:datatype rdf:langString ]
+    ) ;
+.
+
+<definition>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.4, 2.2.1 or 2.3.1 Each vocabulary, Collection or Concept MUST have exactly one title and at least one definition indicated using the skos:prefLabel and the skos:definition predicates respectively that must give textual literal values. Only one definition per language is allowed" ;
+    sh:path skos:definition ;
+    sh:minCount 1 ;
+    sh:uniqueLang true ;
+    sh:or (
+        [ sh:datatype xsd:string ]
+        [ sh:datatype rdf:langString ]
+    ) ;
+.
+
+<created>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.15 - created date - violated" ;
+    sh:path [
+        sh:alternativePath (
+            sdo:dateCreated
+            dcterms:created
+        ) ;
+    ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:or (
+        [ sh:datatype xsd:dateTime ]
+        [ sh:datatype xsd:date ]
+        [ sh:datatype xsd:dateTimeStamp ]
+    ) ;
+.
+
+<modified>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.15 - modified date - violated" ;
+    sh:path [
+        sh:alternativePath (
+            sdo:dateModified
+            dcterms:modified
+        ) ;
+    ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:or (
+        [ sh:datatype xsd:dateTime ]
+        [ sh:datatype xsd:date ]
+        [ sh:datatype xsd:dateTimeStamp ]
+    ) ;
+.
+
+<creator>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.6 Each vocabulary MUST have at least one creator, indicated using sdo:creator or dcterms:creator predicate and exactly one publisher, indicated using sdo:publisher or dcterms:publisher, all of which MUST be IRIs indicating instances of sdo:Person, or sdo:Organization. This error message is for creator" ;
+    sh:path [
+        sh:alternativePath (
+            sdo:creator
+            dcterms:creator
+        ) ;
+    ] ;
+    sh:minCount 1 ;
+
+    sh:or (
+        [ sh:class sdo:Organization ]
+        [ sh:class sdo:Person ]
+    ) ;
+.
+
+<publisher>
+    a sh:PropertyShape ;
+    sh:path [
+        sh:alternativePath (
+            sdo:publisher
+            dcterms:publisher
+        ) ;
+    ] ;
+    sh:minCount 1 ;
+    sh:message "Requirement 2.1.6 Each vocabulary MUST have at least one creator, indicated using sdo:creator or dcterms:creator predicate and exactly one publisher, indicated using sdo:publisher or dcterms:publisher, all of which MUST be IRIs indicating instances of sdo:Person, or sdo:Organization. This error message is for publisher" ;
+    sh:or (
+        [ sh:class sdo:Organization ]
+        [ sh:class sdo:Person ]
+    ) ;
+.
+
+<provenance-properties-01>
+    a sh:PropertyShape ;
+    sh:path prov:wasDerivedFrom ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+.
+
+<provenance-properties-02>
+    a sh:PropertyShape ;
+    sh:path sdo:citation ;
+    sh:minCount 1 ;
+    sh:or (
+        [ sh:datatype xsd:anyURI ]
+        [ sh:datatype xsd:string ]
+    ) ;
+.
+
+<provenance-properties-03>
+    a sh:PropertyShape ;
+    sh:path dcterms:source ;
+    sh:minCount 1 ;
+    sh:or (
+        [ sh:datatype xsd:anyURI ]
+        [ sh:datatype xsd:string ]
+    ) ;
+.
+
+<provenance-properties-04>
+    a sh:PropertyShape ;
+    sh:path skos:historyNote ;
+    sh:minCount 1 ;
+    sh:or (
+        [ sh:datatype rdf:langString ]
+        [ sh:datatype xsd:string ]
+    ) ;
+.
+
+<provenance-properties-05>
+    a sh:PropertyShape ;
+    sh:path dcterms:provenance ;
+    sh:minCount 1 ;
+    sh:or (
+        [ sh:datatype rdf:langString ]
+        [ sh:datatype xsd:string ]
+    ) ;
+.
+
+<inScheme>
+    a sh:PropertyShape ;
+    sh:path skos:inScheme ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:message "Requirement 2.3.3 Each Concept in a vocabulary MUST indicate that it appears within that vocabulary's hierarchy of Concepts either directly by use of the skos:topConceptOf predicate indicating the vocabulary or indirectly by use of one or more skos:broader / skos:narrower predicates placing the Concept within a chain of other Concepts, the top concept of which uses the skos:topConceptOf predicate to indicate the vocabulary" ;
+.
+
+<minConcepts>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.8 All Concept instances within a Concept Scheme MUST be contained in a single term hierarchy using skos:hasTopConcept / skos:topConceptOf predicates indicating the broadest Concepts in the vocabulary and then skos:broader and/or skos:narrower predicates for all non-broadest Concepts in a hierarchy that contains no cycles" ;
+    sh:path skos:inScheme ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+        sh:class skos:ConceptScheme ;
+.
+
+<qualifiedDerivation>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.11 The derivation status of the vocabulary SHOULD be given should be given with the predicate prov:qualifiedDerivation indicating a Blank Node that contains the predicated prov:entity, to indicate the vocabulary derived from and prov:hadRole to indicate the mode of derivation which SHOULD be taken from the Vocabulary Derivation Modes vocabulary (https://linked.data.gov.au/def/vocdermods)" ;
+    sh:path prov:qualifiedDerivation ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+.
+
+<qualifiedDerivation-entity>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.11 If a vocabulary has a qualified derivation given, it must then give a prove:entity predicate within the derivation" ;
+    sh:path prov:entity ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+.
+
+<qualifiedDerivation-hadRole>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.11 If a vocabulary has a qualified derivation given, it must then give a prove:hadRole predicate within the derivation" ;
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+.
+
+<theming>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.12 High-level theming of a vocabulary SHOULD be given by using the sdo:keywords predicate indicating Concepts from another vocabulary. Alternatively, dcat:theme MAY be used. Text literal values for either predicate SHOULD NOT be used" ;
+    sh:path [
+        sh:alternativePath (
+            sdo:keywords
+            dcat:theme
+        ) ;
+    ] ;
+    sh:nodeKind sh:IRI ;
+.
+
+<license>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.13 Any licence pertaining to the reuse of a vocabulary's content SHOULD be given using the sdo:license predicate preferentially indicating the IRI of a license if in RDF form or a literal URL (datatype xsd:anyURI) if online but not in RDF form. If the licence is expressed in test, a literal text field may be indicated" ;
+    sh:path sdo:license ;
+    sh:nodeKind sh:IRI ;
+    sh:or (
+        [ sh:nodeKind sh:IRI ]
+        [ sh:datatype xsd:anyURI ]
+        [ sh:datatype xsd:string ]
+    )
+.
+
+<copyrightHolder>
+    a sh:PropertyShape ;
+    sh:message "Requirement 2.1.14 The copyright holder for the vocabulary SHOULD be given using the sdo:copyrightHolder predicate preferentially indicating the IRI of an Agent or a Blank Node instance of an Agent containing details as per Agent requirements. A prov:qualifiedAttribution predicate indicating an Agent with the prov:hadRole predicate indicating the value isorole:rightsHolder may be used instead of sdo:copyrightHolder" ;
+    sh:path sdo:copyrightHolder ;
+    sh:nodeKind sh:IRI ;
+    sh:nodeKind sh:IRI ;
+.

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -8,8 +8,7 @@ from urllib.parse import urlsplit
 
 import openpyxl
 from openpyxl.styles import Alignment
-from rdflib import Graph, Literal
-from rdflib.namespace import DCTERMS, OWL, RDF, SKOS, XSD
+from rdflib import DCTERMS, OWL, RDF, SKOS, XSD, Graph, Literal
 
 from voc4cat import config
 from voc4cat.checks import Voc4catError

--- a/tests/data/concept-scheme-simple.ttl
+++ b/tests/data/concept-scheme-simple.ttl
@@ -5,10 +5,13 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sdo: <https://schema.org/> .
 
 ex:test10 a skos:Collection ;
     dcterms:identifier "test10"^^xsd:token ;
     dcterms:isPartOf <http://example.org/test/> ;
+    rdfs:isDefinedBy <https://example.org/test> ;
+    skos:inScheme <https://example.org> ;
     dcterms:provenance "0000-0001-2345-6789"@en ;
     skos:definition "def for con"@en ;
     skos:member ex:test01,
@@ -85,14 +88,18 @@ ex:test03 a skos:Concept ;
     skos:narrower ex:test04 ;
     skos:prefLabel "term3"@en .
 
+<http://example.org/nfdi4cat/> a sdo:Organization ;
+    sdo:name "NFDI4Cat" ;
+    sdo:url "http://example.org/nfdi4cat/"^^xsd:anyURI .
+
 <http://example.org/test/> a skos:ConceptScheme ;
     dcterms:created "2022-12-01"^^xsd:date ;
-    dcterms:creator <https://www.catalysis.de/> ;
+    dcterms:creator <http://example.org/nfdi4cat/> ;
     dcterms:hasPart ex:test10 ;
     dcterms:identifier ""^^xsd:token ;
     dcterms:modified "2022-12-01"^^xsd:date ;
     dcterms:provenance "0000-0001-2345-6789"@en ;
-    dcterms:publisher <http://example.org/nfdi4cat/> ;
+    dcterms:publisher <http://example.org/nfdi4cat/>;
     owl:versionInfo "0.1" ;
     skos:definition "A concept scheme for unit testing voc4cat."@en ;
     skos:hasTopConcept ex:test01,

--- a/tests/templ_versions/043_exhaustive_example_perfect_output.ttl
+++ b/tests/templ_versions/043_exhaustive_example_perfect_output.ttl
@@ -5,11 +5,14 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sdo: <https://schema.org/> .
 
 <http://example.org/example_collection_uri> a skos:Collection ;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
     dcterms:identifier "example_collection_uri"^^xsd:token ;
     dcterms:isPartOf cs: ;
-    dcterms:provenance "Example Collection Provenance"@en ;
+    skos:historyNote "Example Collection Provenance"@en ;
     skos:definition "Example Collection Definition"@en ;
     skos:member <http://example.org/example_collection_member_1>,
         <http://example.org/example_collection_member_2>,
@@ -22,13 +25,17 @@
 
 <http://example.org/exhaustive_children_example_3> skos:broader <http://example.org/exhaustive_concept_iri> .
 
+<https://linked.data.gov.au/org/cgi-gtwg> a sdo:Organization ;
+    sdo:name "https://linked.data.gov.au/org/cgi-gtwg"@en ;
+    sdo:url "https://linked.data.gov.au/org/cgi-gtwg"^^xsd:anyURI .
+
 cs: a skos:ConceptScheme ;
     dcterms:identifier "exhaustive_concept_scheme_vocabulary_iri"^^xsd:token ;
     dcterms:created "2022-03-07"^^xsd:date ;
     dcterms:creator <https://linked.data.gov.au/org/gsq> ;
     dcterms:hasPart <http://example.org/example_collection_uri> ;
     dcterms:modified "2022-03-10"^^xsd:date ;
-    dcterms:provenance "Example Provenance"@en ;
+    skos:historyNote "Example Provenance"@en ;
     dcterms:publisher <https://linked.data.gov.au/org/cgi-gtwg> ;
     rdfs:seeAlso "1.2.3.4" ;
     owl:versionInfo "0.1" ;
@@ -39,7 +46,7 @@ cs: a skos:ConceptScheme ;
 
 <http://example.org/exhaustive_concept_iri> a skos:Concept ;
     dcterms:identifier "exhaustive_concept_iri"^^xsd:token ;
-    dcterms:provenance "Example Exhaustive Provenance"@en ;
+    skos:historyNote "Example Exhaustive Provenance"@en ;
     rdfs:isDefinedBy <http://example.org/exhaustive_concept_source_vocabulary_iri> ;
     skos:altLabel "example exhaustive concept alternate label"@en ;
     skos:broadMatch <http://example.org/example_broad_match> ;

--- a/tests/test_template043.py
+++ b/tests/test_template043.py
@@ -4,8 +4,7 @@ from unittest import mock
 
 import pytest
 import voc4cat
-from rdflib import Graph, Literal, URIRef, compare
-from rdflib.namespace import DCTERMS, SKOS
+from rdflib import SKOS, Graph, Literal, URIRef, compare
 from voc4cat import convert
 from voc4cat.utils import ConversionError
 
@@ -26,7 +25,7 @@ def test_simple():
         Path(__file__).parent / "templ_versions" / "043_simple_valid.xlsx",
         output_type="graph",
     )
-    assert len(g) == 142  # noqa: PLR2004
+    assert len(g) == 147  # noqa: PLR2004
     assert (
         URIRef(
             "http://resource.geosciml.org/classifierscheme/cgi/2016.01/particletype"
@@ -36,7 +35,7 @@ def test_simple():
     ) in g, "PrefLabel for vocab is not correct"
     assert (
         URIRef("http://resource.geosciml.org/classifier/cgi/particletype/bioclast"),
-        DCTERMS.provenance,
+        SKOS.historyNote,
         Literal("NADM SLTTs 2004", lang="en"),
     ) in g, "Provenance for vocab is not correct"
 

--- a/tests/test_template043.py
+++ b/tests/test_template043.py
@@ -17,7 +17,7 @@ def test_empty_template():
             test_file,
             output_type="file",
         )
-    assert "9 validation errors for ConceptScheme" in str(e)
+    assert "8 validation errors for ConceptScheme" in str(e)
 
 
 def test_simple():


### PR DESCRIPTION
Upgrading to the current vocpub-profile (v4.7) requires only few changes. See first commit for how the example vocabulary has to be modified to pass validation. Since vocpub profile v4.7 uses `skos:historyNote`  instead of `dcterms:provenance` this PR also solves #122.

Closes #198
Closes #122