### PR TITLE
Move colorama to main dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Release 0.8.1 (2024-02-20)
+
+Bug fixes:
+
+- Add colorama as main dependency. #204
+
 ## Release 0.8.0 (2024-02-19)
 
 Features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
 
 dependencies = [
   "base32-crockford >= 0.3.0",
+  "colorama",
   "curies >= 0.6.6",
   "networkx >= 2.8",
   "openpyxl >= 3.0.9",
@@ -62,8 +63,6 @@ tests = [
   "pytest",
   "pytest-subprocess",
   "coverage",
-  # pytest has a windows-only dependency on colorama, but it's needed in CI for color output.
-  "colorama",
 ]
 lint = [
   "black",


### PR DESCRIPTION
It did not show up before probably because colorama was indirectly included via other dependencies but now voc4cat jobs fail.