### PR TITLE
Fix writing to wrong file location for sub-command "join" with "--outbox" option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
   -  id: check-toml
   -  id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 24.1.1
+  rev: 24.2.0
   hooks:
   -  id: black
      args: ['--target-version', 'py38']
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.15
+  rev: v0.2.2
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Release 0.8.3 (2024-02-28)
+
+Bug fixes:
+
+- Fix writing to wrong file location for sub-command "join" with "--outbox" option. #211, #212 
+- Fix clearing of cells with hyperlinks in xlsx by openpyxl. #209, #210
+
 ## Release 0.8.2 (2024-02-21)
 
 Bug fixes:

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -489,7 +489,7 @@ def transform(args):
         if args.join:
             vocab_graph = join_split_turtle(rdf_dir)
             dest = (
-                (args.outdir / rdf_dir).with_suffix(".ttl").name
+                (args.outdir / rdf_dir.name).with_suffix(".ttl")
                 if args.outdir
                 else rdf_dir.with_suffix(".ttl")
             )

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -582,8 +582,7 @@ def test_split(monkeypatch, datadir, tmp_path, opt, caplog):
 
 @pytest.mark.parametrize(
     "opt",
-    [None, "--inplace"],
-    ids=["default", "inplace"],
+    [None, "inplace", "outdir"],
 )
 def test_join(monkeypatch, datadir, tmp_path, opt, caplog):
     monkeypatch.chdir(tmp_path)
@@ -592,18 +591,25 @@ def test_join(monkeypatch, datadir, tmp_path, opt, caplog):
     main_cli(["transform", "-v", "--split", "--inplace", str(tmp_path)])
     # join files again as test
     cmd = ["transform", "-v", "--join"]
-    if opt:
+    if opt == "inplace":
         cmd.append("--inplace")
+    elif opt == "outdir":
+        cmd.append("--outdir")
+        cmd.append(str(tmp_path / "outdir"))
     cmd.append(str(tmp_path))
 
     with caplog.at_level(logging.DEBUG):
+        print("cmd:", cmd)
         main_cli(cmd)
     assert "-> joined vocabulary into" in caplog.text
 
     vocdir = (tmp_path / CS_SIMPLE_TURTLE).with_suffix("")
     assert (vocdir.parent / CS_SIMPLE_TURTLE).exists()
-    if opt:
+    if opt == "inplace":
         assert not vocdir.exists()
+    elif opt == "outdir":
+        print("\nout (?):", (tmp_path / "outdir" / CS_SIMPLE_TURTLE))
+        assert (tmp_path / "outdir" / CS_SIMPLE_TURTLE).exists()
 
 
 @mock.patch.dict(


### PR DESCRIPTION
The issue was caused by wrong code for `--outbox` option. This PR adds a test and a fix.

Closes #211