### PR TITLE
Make transform --join output conform to vocpub profile 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Change log
 
+## Release 0.8.4 (2024-03-04)
+
+Bug fixes:
+
+- Fix transform join subcommand to produce vocpub-4.7-conform turtle file. #213
+
 ## Release 0.8.3 (2024-02-28)
 
 Bug fixes:
 
-- Fix writing to wrong file location for sub-command "join" with "--outbox" option. #211, #212 
+- Fix writing to wrong file location for sub-command "join" with "--outbox" option. #211, #212
 - Fix clearing of cells with hyperlinks in xlsx by openpyxl. #209, #210
 
 ## Release 0.8.2 (2024-02-21)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,12 +168,19 @@ exclude = [
     "*.egg",
     ".*",
 ]
+
+# Assume Python 3.8
+target-version = "py38"
+
+# Same as Black.
+line-length = 88
+
+[tool.ruff.lint]
+
 ignore = [
     "B905",  # zip() without an explicit strict= parameter set. (requires python >= 3.10)
     "E501",  # line too long
 ]
-# Same as Black.
-line-length = 88
 
 # Avoid trying to fix these violations
 unfixable = [
@@ -218,19 +225,17 @@ select = [
     # NumPy-specific rules (NPY)
     "RUF",  # Ruff-specific rules
 ]
-# Assume Python 3.8
-target-version = "py38"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
   "S101",   # assert in tests is OK
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 # Flake8-mccabe uses a default level of 7, ruff of 10.
 max-complexity = 10
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 # Allow Pydantic's `@validator` decorator to trigger class method treatment.
 classmethod-decorators = [
   "classmethod",


### PR DESCRIPTION
transform --join was not adding metadata for the vocabulary which made the resulting turtle file incompatible with vocpub profile 4.7.

This is a quick fix. A better solution would be to have the additional metadata required by vocpub profile 4.7 in a metadata-turtle file (when the vocab is in split form).