### PR TITLE
Adapt to v4.4 of actions/upload-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     - name: Upload coverage data
       uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a
       with:
+        include-hidden-files: true
         name: coverage-data-${{ matrix.python-version }}
         path: .coverage.*
 


### PR DESCRIPTION
actions/upload-artifact added in v4.4 a [breaking change](https://github.com/actions/upload-artifact/releases/tag/v4.4.0) by excluding hidden files by default. Unfortunately all coverage files are hidden files so the aggregation of coverage data failed.