### PR TITLE
Fix compatibility with minor Python updates (3.12.6 to 3.12.7, 3.11.7 to 3.11.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "colorama",
   "curies >= 0.6.6",
   "networkx >= 2.8",
-  "openpyxl >= 3.0.9",
+  "openpyxl >= 3.1.5",
   "pillow >= 9.1.0",
   "pydantic < 2.0.0",
   "pyLODE < 3.0.0",

--- a/src/voc4cat/cli.py
+++ b/src/voc4cat/cli.py
@@ -386,7 +386,7 @@ def add_docs_subparser(subparsers, options):
     parser.add_argument(
         "--style",
         help="Select style of html documentation. (default: pylode)",
-        choices=("pylode"),
+        choices=("pylode",),
         default="pylode",
         type=str,
         required=False,


### PR DESCRIPTION
Code fixes: 

- Corrected the `choices` parameter in the `add_docs_subparser` function. This is required due to changes made in argparse in Python 3.12.7.

Dependency updates:

- Updated the version requirement for `openpyxl` from `>= 3.0.9` to `>= 3.1.5`.  This is required since [Python 3.11.8 broke file-closing](https://foss.heptapod.net/openpyxl/openpyxl/-/issues/2149)) in openpyxl on Windows. 

Closes #231