### PR TITLE
Support Python 3.13 & correctly specify minimum version as 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
     strategy:
       matrix:
         python-version:
+        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,7 @@ docs/_build/
 __pypackages__/
 
 # Environments
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: 24.10.0
   hooks:
   -  id: black
-     args: ['--target-version', 'py39']
+     args: ['--target-version', 'py310']
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.7.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,24 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
   -  id: end-of-file-fixer
   -  id: check-yaml
   -  id: check-toml
   -  id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 24.2.0
+  rev: 24.10.0
   hooks:
   -  id: black
-     args: ['--target-version', 'py38']
+     args: ['--target-version', 'py39']
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.2.2
+  rev: v0.7.1
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
+  rev: v2.3.0
   hooks:
   - id: codespell
     additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ voc4cat works on files or folders. If a folder is given all matching files are p
 
 To start you need:
 
-- Python (3.9 or newer)
+- Python (3.10 or newer)
 
 voc4cat is platform independent and should work at least on windows, linux and mac.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ voc4cat works on files or folders. If a folder is given all matching files are p
 
 To start you need:
 
-- Python (3.8 or newer)
+- Python (3.9 or newer)
 
 voc4cat is platform independent and should work at least on windows, linux and mac.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 ]
 license = {text = "BSD-3-Clause"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 keywords = ["SKOS", "vocabulary", "spreadsheet", "xlsx", "linked data", "rdf"]
 
@@ -29,7 +29,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -169,8 +168,8 @@ exclude = [
     ".*",
 ]
 
-# Assume Python 3.9 syntax and semantics for linting.
-target-version = "py39"
+# Assume Python 3.10 syntax and semantics for linting.
+target-version = "py310"
 
 # Same as Black.
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 ]
 license = {text = "BSD-3-Clause"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 keywords = ["SKOS", "vocabulary", "spreadsheet", "xlsx", "linked data", "rdf"]
 
@@ -29,11 +29,11 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
@@ -169,8 +169,8 @@ exclude = [
     ".*",
 ]
 
-# Assume Python 3.8
-target-version = "py38"
+# Assume Python 3.9 syntax and semantics for linting.
+target-version = "py39"
 
 # Same as Black.
 line-length = 88

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -1,7 +1,7 @@
 import logging
 from itertools import chain
 from pathlib import Path
-from typing import Dict, Literal, Union
+from typing import Literal
 
 import pyshacl
 from colorama import Fore, Style
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 def validate_with_profile(
-    data_graph: Union[GraphLike, str, bytes],
+    data_graph: GraphLike | str | bytes,
     profile="vocpub",
     error_level=1,
 ):
@@ -242,10 +242,10 @@ def rdf_to_excel(
         modified=holder["modified"],
         creator=holder["creator"],
         publisher=holder["publisher"],
-        version=holder.get("versionInfo", None),
-        provenance=holder.get("provenance", None),
-        custodian=holder.get("custodian", None),
-        pid=holder.get("pid", None),
+        version=holder.get("versionInfo"),
+        provenance=holder.get("provenance"),
+        custodian=holder.get("custodian"),
+        pid=holder.get("pid"),
     )
     cs.to_excel(wb)
 
@@ -366,7 +366,7 @@ def rdf_to_excel(
     return dest
 
 
-def format_log_msg(result: Dict, colored: bool = False) -> str:
+def format_log_msg(result: dict, colored: bool = False) -> str:
     from rdflib.namespace import SH
 
     formatted_msg = ""

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List, Tuple
 
 from curies import Converter
 from openpyxl import Workbook
@@ -51,7 +50,7 @@ def extract_concepts_and_collections(
     s: Worksheet,
     prefix_converter: Converter,
     vocab_name: str = "",
-) -> Tuple[List[models.Concept], List[models.Collection]]:
+) -> tuple[list[models.Concept], list[models.Collection]]:
     concepts = []
     collections = []
     # Iterating over the concept page and the additional concept page

--- a/src/voc4cat/fields.py
+++ b/src/voc4cat/fields.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, ClassVar, Generator
+from collections.abc import Generator
+from typing import Any, ClassVar
 
 import base32_crockford
 from pydantic import BaseConfig, HttpUrl

--- a/src/voc4cat/models.py
+++ b/src/voc4cat/models.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import os
 from itertools import chain
-from typing import List, Union
 
 from curies import Converter
 from openpyxl import Workbook
@@ -289,19 +288,19 @@ class ConceptScheme(BaseModel):
 
 class Concept(BaseModel):
     uri: AnyHttpUrl
-    pref_label: Union[str, List[str]]
-    alt_labels: List[str] = []
-    pl_language_code: List[str] = []
-    definition: Union[str, List[str]]
-    def_language_code: List[str] = []
-    children: List[AnyHttpUrl] = []
+    pref_label: str | list[str]
+    alt_labels: list[str] = []
+    pl_language_code: list[str] = []
+    definition: str | list[str]
+    def_language_code: list[str] = []
+    children: list[AnyHttpUrl] = []
     source_vocab: AnyHttpUrl | None = None
     provenance: str | None = None
-    related_match: List[AnyHttpUrl] = []
-    close_match: List[AnyHttpUrl] = []
-    exact_match: List[AnyHttpUrl] = []
-    narrow_match: List[AnyHttpUrl] = []
-    broad_match: List[AnyHttpUrl] = []
+    related_match: list[AnyHttpUrl] = []
+    close_match: list[AnyHttpUrl] = []
+    exact_match: list[AnyHttpUrl] = []
+    narrow_match: list[AnyHttpUrl] = []
+    broad_match: list[AnyHttpUrl] = []
     vocab_name: str = Field("", exclude=True)
 
     # We validate with a reusable (external) validators. With a pre-validator,
@@ -477,7 +476,7 @@ class Collection(BaseModel):
     uri: AnyHttpUrl
     pref_label: str
     definition: str
-    members: List[AnyHttpUrl]
+    members: list[AnyHttpUrl]
     provenance: str | None = None
     vocab_name: str = Field("", exclude=True)
 
@@ -528,8 +527,8 @@ class Collection(BaseModel):
 
 class Vocabulary(BaseModel):
     concept_scheme: ConceptScheme
-    concepts: List[Concept]
-    collections: List[Collection]
+    concepts: list[Concept]
+    collections: list[Collection]
 
     def to_graph(self):
         g = self.concept_scheme.to_graph()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def datadir():
     return Path(__file__).resolve().parent / "data"
 
 
-@pytest.fixture()
+@pytest.fixture
 def temp_config():
     """
     Provides a temporary config that can be safely changed in test functions.

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -10,6 +10,7 @@ from test_cli import (
     CS_SIMPLE,
     CS_SIMPLE_TURTLE,
 )
+
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
 from voc4cat.utils import ConversionError

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 from rdflib import RDF, SKOS, Graph
+
 from voc4cat.checks import (
     Voc4catError,
     check_for_removed_iris,
@@ -263,9 +264,12 @@ def test_check_for_removed_iris(  # noqa: PLR0913
     )
     config.load_config(config=config.IDRANGES)
 
-    with caplog.at_level(logging.ERROR), pytest.raises(
-        Voc4catError,
-        match=r"Forbidden removal of 1 concepts\/collections detected. See log for IRIs.",
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(
+            Voc4catError,
+            match=r"Forbidden removal of 1 concepts\/collections detected. See log for IRIs.",
+        ),
     ):
         check_for_removed_iris(original, reduced)
     assert log_text in caplog.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import shutil
 from unittest import mock
 
 import pytest
+
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli, run_cli_app
 
@@ -105,8 +106,11 @@ def test_valid_config(monkeypatch, datadir, caplog, tmp_path, temp_config):
 def test_invalid_outdir(monkeypatch, datadir, tmp_path, caplog):
     monkeypatch.chdir(datadir)
     shutil.copy(datadir / "README.md", tmp_path)
-    with caplog.at_level(logging.ERROR), pytest.raises(
-        Voc4catError, match="Outdir must be a directory but it is a file."
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(
+            Voc4catError, match="Outdir must be a directory but it is a file."
+        ),
     ):
         main_cli(["transform", "--outdir", str(tmp_path / "README.md"), CS_SIMPLE])
     assert "Outdir must be a directory but it is a file." in caplog.text

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,12 +3,13 @@ import shutil
 from pathlib import Path
 
 import pytest
-import voc4cat
 from test_cli import (
     CS_CYCLES,
     CS_CYCLES_TURTLE,
     CS_SIMPLE,
 )
+
+import voc4cat
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
 

--- a/tests/test_dag_util.py
+++ b/tests/test_dag_util.py
@@ -1,4 +1,5 @@
 import pytest
+
 from voc4cat.checks import Voc4catError
 from voc4cat.dag_util import (
     dag_from_indented_text,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -8,6 +8,7 @@ import pytest
 from test_cli import (
     CS_CYCLES_TURTLE,
 )
+
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
 
@@ -32,9 +33,10 @@ def test_build_docs_pylode_ci_no_git(monkeypatch, datadir, tmp_path, caplog):
     shutil.copy(datadir / "valid_idranges.toml", dst / "idranges.toml")
     outdir = dst / "pylode"
 
-    with caplog.at_level(logging.ERROR), mock.patch(
-        "voc4cat.gh_index.subprocess"
-    ) as subprocess:
+    with (
+        caplog.at_level(logging.ERROR),
+        mock.patch("voc4cat.gh_index.subprocess") as subprocess,
+    ):
         subprocess.Popen.return_value.returncode = 1
         main_cli(
             ["docs", "--force", "--style", "pylode", "--outdir", str(outdir), str(dst)]
@@ -51,8 +53,9 @@ def test_build_docs_pylode_ci_no_config(monkeypatch, datadir, tmp_path, caplog):
     shutil.copy(datadir / CS_CYCLES_TURTLE, dst)
     outdir = dst / "pylode"
 
-    with caplog.at_level(logging.ERROR), pytest.raises(
-        Voc4catError, match="Config file not found"
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(Voc4catError, match="Config file not found"),
     ):
         main_cli(
             ["docs", "--force", "--style", "pylode", "--outdir", str(outdir), str(dst)]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pydantic import BaseModel, ValidationError
+
 from voc4cat.fields import Orcid, Ror
 
 

--- a/tests/test_merge_vocab.py
+++ b/tests/test_merge_vocab.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from test_cli import CS_CYCLES_TURTLE, CS_SIMPLE_TURTLE
+
 from voc4cat.merge_vocab import main_cli
 
 
@@ -61,9 +62,10 @@ def test_main_merge_split_vocab_dir(datadir, tmp_path, caplog):
     shutil.copy(datadir / CS_SIMPLE_TURTLE, ttl_inbox / "splitvoc")
     shutil.copy(datadir / CS_SIMPLE_TURTLE, vocab / "splitvoc")
 
-    with caplog.at_level(logging.DEBUG), mock.patch(
-        "voc4cat.merge_vocab.subprocess"
-    ) as subprocess:
+    with (
+        caplog.at_level(logging.DEBUG),
+        mock.patch("voc4cat.merge_vocab.subprocess") as subprocess,
+    ):
         subprocess.Popen.return_value.returncode = 1
         exit_code = main_cli([str(ttl_inbox), str(vocab)])
     assert "Entering directory" in caplog.text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 from pydantic.error_wrappers import ValidationError
 from rdflib import Graph
+
 from voc4cat import config
 from voc4cat.models import Concept, ConceptScheme, reset_curies
 

--- a/tests/test_template043.py
+++ b/tests/test_template043.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-import voc4cat
 from rdflib import SKOS, Graph, Literal, URIRef, compare
+
+import voc4cat
 from voc4cat import convert
 from voc4cat.utils import ConversionError
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -15,6 +15,7 @@ from test_cli import (
     CS_SIMPLE,
     CS_SIMPLE_TURTLE,
 )
+
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
 
@@ -671,8 +672,11 @@ def test_join_with_invalid_envvar(monkeypatch, datadir, tmp_path, caplog):
     # join files again as test
     cmd = ["transform", "-v", "--join"]
     cmd.append(str(tmp_path))
-    with caplog.at_level(logging.ERROR), pytest.raises(
-        Voc4catError, match="Invalid environment variable VOC4CAT_VERSION"
+    with (
+        caplog.at_level(logging.ERROR),
+        pytest.raises(
+            Voc4catError, match="Invalid environment variable VOC4CAT_VERSION"
+        ),
     ):
         main_cli(cmd)
     assert 'Invalid environment variable VOC4CAT_VERSION "2.0"' in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from openpyxl import Workbook, load_workbook
 from openpyxl.worksheet.table import Table
+
 from voc4cat.utils import adjust_length_of_tables, split_and_tidy
 
 


### PR DESCRIPTION
This PR adds Python 3.13 to the test matrix.

The PR also corrects the specification of the minimum Python to Python 3.10. Lifting the minimum version to 3.10 for the linter caused some changes which are also part of this PR.

Closes #232