### PR TITLE
Add alternate name voc4cat-merge for merge_vocab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
 [project.scripts]
 voc4cat = "voc4cat.cli:run_cli_app"
 merge_vocab = "voc4cat.merge_vocab:main_cli"
+voc4cat-merge = "voc4cat.merge_vocab:main_cli"
 
 [tool.hatch.metadata]
 # Hatch disallows direct references for dependencies by default.


### PR DESCRIPTION
This adds "voc4cat" as alternative name for the executable script "merge_vocab".

Closes #240