### PR TITLE
Review dependencies & switch to our pylode-2.x-fork

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# For more on what a CODEOWNERS file does and its syntax see
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, the user dalito
+# will be requested for review when someone opens a pull request.
+*   @dalito

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,16 +36,17 @@ classifiers = [
 ]
 
 dependencies = [
-  "base32-crockford >= 0.3.0",
+  "base32-crockford",
   "colorama",
-  "curies >= 0.6.6",
-  "networkx >= 2.8",
+  "curies < 0.7.10",  # due to pydantic 1.x use in voc4cat-tool
+  "networkx",
   "openpyxl >= 3.1.5",
-  "pillow >= 9.1.0",
+  "pillow",
   "pydantic < 2.0.0",
-  "pyLODE < 3.0.0",
-  "pyshacl >= 0.18.1",
-  "rdflib >= 6.1.1",
+  # official pyLODE 2.x dev has stopped, use dalito´s fork
+  "pyLODE @ git+https://github.com/dalito/pyLODE.git@nfdi4cat-2.x",
+  "pyshacl",
+  "rdflib",
   "tomli>=1.1.0; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
Also remove lower/upper version bounds where not necessary.

We switch away from official pylode-2.x because
- it unnecessarily constrains some dependency-updates by setting upper bounds (e.g. for `rdflib`)
- [our fork](https://github.com/dalito/pyLODE) has several improvements for `voc4cat-tool`-maintained vocabularies over the last official pylode 2.x release.

We could make the doc-generation (and so the pylode-2.x-installation) optional but decided against it for convenience. Please create an issue if you would prefer to install pylode-2.x as optional extra.

This PR also adds a CODEOWNERS file to make it clear to which users PR-reviews should be assigned.