### PR TITLE
Fix typo in action preventing releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     name: Build Python 🐍 distributions 📦 for publishing
     # Don't try to publish from forks
-    if: github.repository == 'nfid4cat/voc4cat-tool'
+    if: github.repository == 'nfdi4cat/voc4cat-tool'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Typo in if-condition of release-action prevented the action from running without error or warning. So the problem was difficult to spot.