### PR TITLE
Make pylode optional (remove from dependencies)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -VV
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip
         python -m pip install --upgrade .[tests]
+        python -m pip install git+https://github.com/dalito/pyLODE.git@nfdi4cat-2.x
 
     - name: Run tests & collect coverage
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ dependencies = [
   "openpyxl >= 3.1.5",
   "pillow",
   "pydantic < 2.0.0",
-  # official pyLODE 2.x dev has stopped, use dalito´s fork
-  "pyLODE @ git+https://github.com/dalito/pyLODE.git@nfdi4cat-2.x",
   "pyshacl",
   "rdflib",
   "tomli>=1.1.0; python_version < '3.11'",

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -330,7 +330,7 @@ def rdf_to_excel(
                 holder["narrow_match"],
                 holder["broad_match"],
             ]
-            ):
+        ):
             row_no_features += 1
 
     row_no = 3

--- a/src/voc4cat/docs.py
+++ b/src/voc4cat/docs.py
@@ -6,13 +6,18 @@ from voc4cat.gh_index import build_multirelease_index
 
 logger = logging.getLogger(__name__)
 
+try:
+    import pylode
+
+    HAS_PYLODE = True
+except ImportError:  # pragma: no cover
+    HAS_PYLODE = False
+
 
 def run_pylode(turtle_file: Path, output_path: Path) -> None:
     """
     Generate pyLODE documentation.
     """
-    import pylode
-
     filename = Path(turtle_file)  # .resolve())
     outdir = output_path / filename.stem
     outdir.mkdir(exist_ok=True)
@@ -70,6 +75,12 @@ def docs(args):
             return
 
         if args.style == "pylode":
+            if not HAS_PYLODE:  # pragma: no cover
+                logger.error(
+                    "Cannot build docs without pyLODE. Install our pylode-2.x fork with: "
+                    '"pip install git+https://github.com/dalito/pyLODE.git@nfdi4cat-2.x"'
+                )
+                return
             run_pylode(file, outdir)
             # generate index.html linking all tagged version in CI
             if os.getenv("CI") is not None:

--- a/src/voc4cat/models.py
+++ b/src/voc4cat/models.py
@@ -434,7 +434,15 @@ class Concept(BaseModel):
             row_no_concepts += 1
 
         # Fill Additional Concept Features sheet
-        if any([self.related_match, self.close_match, self.exact_match, self.narrow_match, self.broad_match]):
+        if any(
+            [
+                self.related_match,
+                self.close_match,
+                self.exact_match,
+                self.narrow_match,
+                self.broad_match,
+            ]
+        ):
             ws = wb["Additional Concept Features"]
             ws[f"A{row_no_features}"] = config.curies_converter.compress(
                 self.uri, passthrough=True

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -12,7 +12,15 @@ from tests.test_cli import (
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
 
+try:
+    import pylode
 
+    HAS_PYLODE = True
+except ImportError:
+    HAS_PYLODE = False
+
+
+@pytest.mark.skipif(not HAS_PYLODE, reason="pyLODE not installed")
 @mock.patch.dict(os.environ, clear=True)  # required to hide gh-action environment vars
 def test_build_docs_pylode(datadir, tmp_path):
     """Check that pylode generates the expected output."""
@@ -24,6 +32,7 @@ def test_build_docs_pylode(datadir, tmp_path):
     assert (outdir / Path(CS_CYCLES_TURTLE).stem / "index.html").exists()
 
 
+@pytest.mark.skipif(not HAS_PYLODE, reason="pyLODE not installed")
 @mock.patch.dict(os.environ, {"CI": "TRUE"})
 def test_build_docs_pylode_ci_no_git(monkeypatch, datadir, tmp_path, caplog):
     """Check that pylode generates additional index.html in CI, git error."""
@@ -45,6 +54,7 @@ def test_build_docs_pylode_ci_no_git(monkeypatch, datadir, tmp_path, caplog):
     assert "git command returned with error" in caplog.text
 
 
+@pytest.mark.skipif(not HAS_PYLODE, reason="pyLODE not installed")
 @mock.patch.dict(os.environ, {"CI": "TRUE"})
 def test_build_docs_pylode_ci_no_config(monkeypatch, datadir, tmp_path, caplog):
     """Check that pylode generates additional index.html in CI, git error."""
@@ -64,6 +74,7 @@ def test_build_docs_pylode_ci_no_config(monkeypatch, datadir, tmp_path, caplog):
     assert "Config file not found" in caplog.text
 
 
+@pytest.mark.skipif(not HAS_PYLODE, reason="pyLODE not installed")
 @pytest.mark.parametrize("git_output", [b"v2022.12.22\n", b""])
 @mock.patch.dict(os.environ, {"CI": "TRUE"})
 def test_build_docs_pylode_in_ci(  # noqa: PLR0913
@@ -91,6 +102,7 @@ def test_build_docs_pylode_in_ci(  # noqa: PLR0913
         assert "v2022.12.22" in caplog.text
 
 
+@pytest.mark.skipif(not HAS_PYLODE, reason="pyLODE not installed")
 @mock.patch.dict(os.environ, clear=True)  # required to hide gh-action environment vars
 def test_build_docs(datadir, tmp_path, caplog):
     """Check overwrite warning and output folder creation."""


### PR DESCRIPTION
This concludes #247.

The reasons to remove the official pylode-2.x as dependency are:
- it unnecessarily constrains some dependency-updates by setting upper bounds (e.g. for `rdflib`)
- [our fork](https://github.com/dalito/pyLODE) has several improvements for `voc4cat-tool`-maintained vocabularies over the last official pyLODE 2.x release.

If a user tries to run the `voc4cat-tool docs` without having pyLODE installed an error message with the install command is shown.