### PR TITLE
Prepare for Release 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Change log
 
-## Release 0.8.4 (2024-03-09)
+## Release 0.8.6 (2025-01-26)
+
+Bug fixes:
+
+- Fix handling of mappings to external vocabularies/ontologies (#242)
+
+Features:
+
+- Support Python 3.13 (#234)
+
+Changes:
+
+- Write only concepts with mapping to "Additional Concept Features" sheet (#246)
+- Add alternate name `voc4cat-merge` for executable script `merge_vocab` by (#243)
+- Make pyLODE optional (remove from dependencies) (#250)
+
+## Release 0.8.5 (2024-03-09)
 
 Bug fixes:
 

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -11,9 +11,9 @@
                   (nfdi4cat/voc4cat). Supported features include conversion between
                   SKOS/turtle and Excel/xlsx, validation, transformations between
                   different representations and documentation generation.},
-  year         = {2022--2023},
+  year         = {2022--2025},
   publisher    = {Zenodo},
-  version      = {v0.7.4},
+  version      = {v0.8.6},
   doi          = {10.5281/zenodo.8277925},
   url          = {https://doi.org/10.5281/zenodo.8277925}
 }

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ For **[voc4cat](https://github.com/nfdi4cat/voc4cat)**, a term collection for ca
   - A command-line tool to convert vocabularies from Excel to SKOS (turtle/rdf) and validate the vocabulary. Validation includes formal validation with SHACL-profiles but also additional checks. The `voc4cat` tool can be run locally but is also well suited for integration in CI-pipelines. It was inspired by [RDFlib/VocExcel](https://github.com/nfdi4cat/VocExcel). Parts of the vocexcel code base were merged into this repository (see git history).
 - **[voc4cat-template](https://github.com/nfdi4cat/voc4cat-template)**
   - A github project template for managing SKOS-vocabularies using a GitHub-based workflows including automation by gh-actions.
-- **[voc4cat-playground](https://github.com/nfdi4cat/voc4cat-playground)**
-  - A testbed for playing with the voc4cat workflow. The playground is a test-deployment of the voc4cat-template.
 - **[voc4cat](https://github.com/nfdi4cat/voc4cat)**
   - A SKOS vocabulary for the catalysis disciplines that uses the voc4cat workflow for real work.
 

--- a/src/voc4cat/merge_vocab.py
+++ b/src/voc4cat/merge_vocab.py
@@ -34,7 +34,8 @@ def main(ttl_inbox: Path, vocab: Path) -> int:
             cmd = ["git", "merge-file", "--theirs", str(exists), str(exists), str(new)]
             logger.info("Running cmd: %s", " ".join(cmd))
             outp = subprocess.run(cmd, capture_output=True, check=False)  # noqa: S603
-            logger.info("Cmd output: %s", outp.stdout)
+            if outp.stdout:
+                logger.info("Cmd output: %s", outp.stdout)
             if retcode := outp.returncode != 0:
                 break
         else:


### PR DESCRIPTION
- Update change log
- Remove reference to archived voc4cat-playground
- Updates date and version in CITATION.cff

Other changes
- Suppress empty output log messages from merge_vocab

Related: #245