### PR TITLE
Fix jumping over rows when writing concepts to xlsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Release 0.8.8 (2025-01-27)
+
+0.8.8 only contains a fix for a bug introduced in 0.8.6.
+
+Bug fixes:
+
+- Fix jumping over every second row when writing concepts to xlsx (#254 fixed in #255)
+
 ## Release 0.8.6 / 0.8.7 (2025-01-26)
 
 0.8.7 only adds a missed commit with the CHANGENOTES and README updates.

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -320,7 +320,7 @@ def rdf_to_excel(
             broad_match=holder["broad_match"],
             vocab_name=vocab_name,
         ).to_excel(wb, row_no_concepts, row_no_features)
-        row_no_concepts += 1
+
         # only go to next row in "Additional Concepts Features" if there are any mappings
         if any(
             [

--- a/src/voc4cat/models.py
+++ b/src/voc4cat/models.py
@@ -381,6 +381,8 @@ class Concept(BaseModel):
 
         Non-labels like Children, Provenance are reported only for the first
         language. If "en" is among the used languages, it is reported first.
+
+        Return the row number of next row after the ones filled.
         """
         ws = wb["Concepts"]
 


### PR DESCRIPTION
This fixes a bug introduced in v0.8.6 yesterday.

Closes #254
