### PR TITLE
Add style-copying of first data row in tables to following

### DIFF
--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import openpyxl
 from openpyxl.styles import PatternFill
 
-from voc4cat import profiles
+from voc4cat import config, profiles
 from voc4cat.checks import (
     Voc4catError,
     check_for_removed_iris,
@@ -88,7 +88,10 @@ def check_xlsx(fpath: Path, outfile: Path) -> int:
         wb.save(outfile)
         logger.info("-> Saved file with highlighted errors as %s", outfile)
         # Extend size (length) of tables in all sheets
-        adjust_length_of_tables(outfile)
+        adjust_length_of_tables(
+            outfile,
+            rows_pre_allocated=config.xlsx_rows_pre_allocated
+        )
         return
 
     logger.info("-> xlsx check passed for file: %s", fpath)

--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -29,6 +29,9 @@ curies_converter: Converter = Converter.from_prefix_map(
     {prefix: str(url) for prefix, url in NamespaceManager(Graph()).namespaces()}
 )
 
+# Empty rows added to the tables. The keys in the dict must match the table names exactly.
+xlsx_rows_pre_allocated={"Concepts": 25, "Additional Concept Features": 25, "Collections": 25}
+
 # === Configuration imported from idranges.toml stored as pydantic model ===
 
 class Checks(BaseModel):

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -472,4 +472,7 @@ def convert(args):
             rdf_to_excel(file, output_file_path, template_file_path=args.template)
             logger.info("-> successfully converted to %s", output_file_path)
             # Extend size (length) of tables in all sheets
-            adjust_length_of_tables(output_file_path)
+            adjust_length_of_tables(
+                output_file_path,
+                rows_pre_allocated=config.xlsx_rows_pre_allocated
+            )

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -474,7 +474,11 @@ def _transform_xlsx(file, args):
         logger.debug("-> nothing to do for xlsx files!")
 
     # Extend size (length) of tables in all sheets
-    adjust_length_of_tables(outfile)
+    adjust_length_of_tables(
+        outfile,
+        rows_pre_allocated=config.xlsx_rows_pre_allocated
+    )
+
 
 
 def _transform_rdf(file, args):

--- a/src/voc4cat/utils.py
+++ b/src/voc4cat/utils.py
@@ -5,7 +5,7 @@ from copy import copy
 from pathlib import Path
 
 from openpyxl import load_workbook
-from openpyxl.utils.cell import coordinate_from_string
+from openpyxl.utils.cell import column_index_from_string, coordinate_from_string
 from openpyxl.workbook.workbook import Workbook
 from openpyxl.worksheet.table import Table
 
@@ -85,37 +85,97 @@ def has_file_in_multiple_formats(dir_):
     return [x for x in file_names if x in seen or seen.add(x)]
 
 
-def adjust_length_of_tables(wb_path):
+def adjust_length_of_tables(wb_path:Path, rows_pre_allocated:dict[str,int]|int=0, copy_style:bool=True) -> None:
     """Expand length of all tables in workbook to include all filled rows
 
     For all tables in the workbook the table is expanded to include the last
-    row with content. Note that tables are not shrunk by this method if they
-    contain empty rows at the end.
+    row with from a block of content plus a number of <rows_pre_allocated>
+    additional rows. The number can be set for each sheet individually by
+    using a dictionary with sheet names as keys and the number of rows as
+    values. If a sheet is not in the dictionary, the default value is used.
+
+    Note that tables are not shrunk by this method if they contain empty
+    rows at the end.
+
+    If copy_style is True, the style of the first row in the table is copied
+    to all following rows.
     """
+    if isinstance(rows_pre_allocated, int):
+        rows_pre_allocated = {sheet: rows_pre_allocated for sheet in load_workbook(wb_path).sheetnames}
+    elif isinstance(rows_pre_allocated, dict):
+        for sheet_name in load_workbook(wb_path).sheetnames:
+            if sheet_name not in rows_pre_allocated:
+                rows_pre_allocated[sheet_name] = 0  # set default value for missing sheets
+    else:
+        raise ValueError("rows_pre_allocated must be an int or a dict")
+
     wb = load_workbook(wb_path)
+
 
     for ws in wb.sheetnames:
         for t_name in list(wb[ws].tables):
             old_range = wb[ws].tables[t_name].ref  # "A2:I20"
             start, end = old_range.split(":")
-            end_col, _end_row = coordinate_from_string(end)
-            adjusted = f"{start}:{end_col}{wb[ws].max_row}"
-            if adjusted == old_range:
-                continue
-            # Expanding the table is not possible with openpyxl. Instead a too
-            # short table is removed, and a new adjusted table is created.
-            style = copy(wb[ws].tables[t_name].tableStyleInfo)
-            del wb[ws].tables[t_name]
-            newtab = Table(displayName=t_name, ref=adjusted)
-            newtab.tableStyleInfo = style
-            wb[ws].add_table(newtab)
-            logger.debug(
-                'Adjusted table "%s" in sheet "%s" from {%s} to {%s}.',
-                t_name,
-                wb[ws].title,
-                old_range,
-                adjusted,
-            )
+            start_col_str, start_row = coordinate_from_string(start)
+            start_col = column_index_from_string(start_col_str)
+            end_col_str, end_row = coordinate_from_string(end)
+            end_col = column_index_from_string(end_col_str)
+
+            # find last row with content in table
+            for row in range(1, end_row + 1):
+                row_has_content = any(
+                    wb[ws].cell(row=row, column=col).value for col in range(start_col, end_col + 1)
+                )
+                if not row_has_content:
+                    break
+
+            new_last_row = max(row - 1 + rows_pre_allocated[ws], wb[ws].max_row)
+            adjusted = f"{start}:{end_col_str}{new_last_row}"
+
+            if adjusted != old_range:
+                # Expanding the table is not possible with openpyxl. Instead a too
+                # short table is removed, and a new adjusted table is created.
+                style = copy(wb[ws].tables[t_name].tableStyleInfo)
+                del wb[ws].tables[t_name]
+                newtab = Table(displayName=t_name, ref=adjusted)
+                newtab.tableStyleInfo = style
+                wb[ws].add_table(newtab)
+                logger.debug(
+                    'Adjusted table "%s" in sheet "%s" from {%s} to {%s}.',
+                    t_name,
+                    wb[ws].title,
+                    old_range,
+                    adjusted,
+                )
+            if copy_style:
+                # Read styles from first row
+                styles_in_row = []
+                for col in range(start_col, end_col + 1):
+                    cell = wb[ws].cell(row = start_row + 1, column = col)
+                    cell_styles = {}
+                    for attr in ["alignment", "border", "font", "fill"]:
+                        cell_styles[attr] = copy(getattr(cell, attr))
+                    styles_in_row.append(cell_styles)
+
+                # Apply styles to all following rows
+                for row in range(start_row + 2, new_last_row + 1):
+                    for col, cell_styles in enumerate(styles_in_row):
+                        cell = wb[ws].cell(row = row, column = start_col + col)
+                        for style, styles_obj in cell_styles.items():
+                            # Store indentation for sheet "Concepts", pref.label column
+                            keep_indent = (col == 1 and ws == "Concepts" and style == "alignment")
+                            if keep_indent and cell.alignment.indent:
+                                indent = cell.alignment.indent
+                                cell_alignment = copy(styles_obj)
+                                cell_alignment.indent = indent
+                                setattr(cell, style, cell_alignment)
+                            else:
+                                # set style
+                                setattr(cell, style, styles_obj)
+
+            # reset row height for all table rows including header to default
+            for row in range(start_row, new_last_row + 1):
+                wb[ws].row_dimensions[row].height = None
 
     wb.save(wb_path)
     wb.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
+import logging
+
 from openpyxl import Workbook, load_workbook
+from openpyxl.styles import Alignment, Font
 from openpyxl.worksheet.table import Table
 
 from voc4cat.utils import adjust_length_of_tables, split_and_tidy
@@ -16,10 +19,12 @@ def test_trailing_comma():
     assert split_and_tidy("a,b,") == ["a", "b"]
 
 
-def test_expand_tables(tmp_path):
+def test_expand_tables(tmp_path, caplog):
+    caplog.set_level(logging.DEBUG)
     test_wb = tmp_path / "table.xlsx"
     wb = Workbook()
     ws = wb.active
+    ws.title = "Concepts"
     ws.append(["Letter", "value"])  # table header
     data = [
         ["A", 1],
@@ -29,12 +34,40 @@ def test_expand_tables(tmp_path):
         ws.append(row)
     tab = Table(displayName="Table1", ref="A1:B3")
     ws.add_table(tab)
+    # style A2 with bold font
+    ws["A2"].font = Font(bold=True)
+    ws["B3"].alignment = Alignment(indent=2.0)
     ws["A5"] = "X"
     wb.save(test_wb)
 
-    adjust_length_of_tables(test_wb)
+    print(f"\nFile: {test_wb}")
 
+    # Test with no expansion of table beyond last row used.
+    adjust_length_of_tables(test_wb, rows_pre_allocated=0, copy_style=False)
     wb = load_workbook(test_wb)
     name, table_range = wb.active.tables.items()[0]
     assert name == "Table1"
     assert table_range == "A1:B5"
+    assert "from {A1:B3} to {A1:B5}" in caplog.text
+    assert not ws["A3"].font.bold
+
+
+    caplog.clear()
+    # Test with expansion of table given rows beyond last data block row.
+    adjust_length_of_tables(test_wb, rows_pre_allocated=5) # adds 5 rows (default of rows_pre_allocated)
+    wb = load_workbook(test_wb)
+    name, table_range = wb.active.tables.items()[0]
+    assert name == "Table1"
+    assert table_range == "A1:B8"
+    assert "from {A1:B5} to {A1:B8}" in caplog.text
+    # alignment should be kept in each row col B in sheet "Concepts"
+    assert wb["Concepts"]["B3"].alignment.indent == 2.0
+
+    caplog.clear()
+    # Run once again: The size should not change because the contents are the same
+    adjust_length_of_tables(test_wb, rows_pre_allocated={"Sheet": 5})  # add 5 rows
+    wb = load_workbook(test_wb)
+    name, table_range = wb.active.tables.items()[0]
+    assert name == "Table1"
+    assert table_range == "A1:B8"
+    assert not caplog.text


### PR DESCRIPTION
This adds
- copying of the styling of the first data row in all tables to all following rows
- an option to append a number of formatted empty rows to the end of tables. We add 25 empty rows in the sheets "Concepts", "Additional Concept Features" and "Collection". The default is to add no empty row. The number for empty-rows-per-table are not read from the config file (YAGNI) but are hard-coded for now.
- setting auto-height for rows (when opening in Excel)

Closes #260