### PR TITLE
Change to PEP-639 license spec. Upgrade formatter.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,22 +4,20 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:
-  -  id: end-of-file-fixer
-  -  id: check-yaml
-  -  id: check-toml
-  -  id: trailing-whitespace
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-  -  id: black
-     args: ['--target-version', 'py310']
+    -  id: end-of-file-fixer
+    -  id: check-yaml
+    -  id: check-toml
+    -  id: trailing-whitespace
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.3
+  rev: v0.11.2
   hooks:
-  - id: ruff
-    args: [--fix, --exit-non-zero-on-fix]
+    # Run the linter.
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+    # Run the formatter.
+    - id: ruff-format
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -16,7 +16,8 @@ authors = [
 maintainers = [
   {name = "David Linke", email = "david.linke@catalysis.de"},
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = [ "LICENSE" ]
 readme = "README.md"
 requires-python = ">=3.10"
 
@@ -27,7 +28,6 @@ classifiers = [
   "Programming Language :: Python",
   "Environment :: Console",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,12 +63,11 @@ tests = [
   "coverage",
 ]
 lint = [
-  "black",
+  "ruff",
 ]
 dev = [
     # Recursively including the project's own optional dependencies requires pip>=21.2
     "voc4cat[tests,lint]",
-    "ruff",
 ]
 
 [project.scripts]

--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -89,8 +89,7 @@ def check_xlsx(fpath: Path, outfile: Path) -> int:
         logger.info("-> Saved file with highlighted errors as %s", outfile)
         # Extend size (length) of tables in all sheets
         adjust_length_of_tables(
-            outfile,
-            rows_pre_allocated=config.xlsx_rows_pre_allocated
+            outfile, rows_pre_allocated=config.xlsx_rows_pre_allocated
         )
         return
 

--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -30,9 +30,14 @@ curies_converter: Converter = Converter.from_prefix_map(
 )
 
 # Empty rows added to the tables. The keys in the dict must match the table names exactly.
-xlsx_rows_pre_allocated={"Concepts": 25, "Additional Concept Features": 25, "Collections": 25}
+xlsx_rows_pre_allocated = {
+    "Concepts": 25,
+    "Additional Concept Features": 25,
+    "Collections": 25,
+}
 
 # === Configuration imported from idranges.toml stored as pydantic model ===
+
 
 class Checks(BaseModel):
     allow_delete: bool = False

--- a/src/voc4cat/convert.py
+++ b/src/voc4cat/convert.py
@@ -396,12 +396,12 @@ def format_log_msg(result: dict, colored: bool = False) -> str:
     from rdflib.namespace import SH
 
     formatted_msg = ""
-    message = f"""Validation Result in {result['sourceConstraintComponent'].split(str(SH))[1]} ({result['sourceConstraintComponent']}):
-\tSeverity: sh:{result['resultSeverity'].split(str(SH))[1]}
-\tSource Shape: <{result['sourceShape']}>
-\tFocus Node: <{result['focusNode']}>
-\tValue Node: <{result.get('value', '')}>
-\tMessage: {result['resultMessage']}
+    message = f"""Validation Result in {result["sourceConstraintComponent"].split(str(SH))[1]} ({result["sourceConstraintComponent"]}):
+\tSeverity: sh:{result["resultSeverity"].split(str(SH))[1]}
+\tSource Shape: <{result["sourceShape"]}>
+\tFocus Node: <{result["focusNode"]}>
+\tValue Node: <{result.get("value", "")}>
+\tMessage: {result["resultMessage"]}
 """
     if result["resultSeverity"] == str(SH.Info):
         formatted_msg = (

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -34,7 +34,7 @@ def write_prefix_sheet(wb: Workbook, prefix_map):
         ws.append([prefix, iri])
 
 
-def split_multi_iri(cell_value: str|None, prefix_converter: Converter) -> list[str]:
+def split_multi_iri(cell_value: str | None, prefix_converter: Converter) -> list[str]:
     """
     Split a string of IRIs separated by a comma into a list of IRIs
     """
@@ -53,7 +53,6 @@ def extract_concepts_and_collections(
     s: Worksheet,
     vocab_name: str = "",
 ) -> tuple[list[models.Concept], list[models.Collection]]:
-
     concepts = []
     collections = []
     concept_data = {}
@@ -148,7 +147,7 @@ def extract_concepts_and_collections(
     return concepts, collections
 
 
-def extract_concept_scheme(sheet: Worksheet,vocab_name: str=""):
+def extract_concept_scheme(sheet: Worksheet, vocab_name: str = ""):
     prefix_converter = config.CURIES_CONVERTER_MAP.get(vocab_name, Converter({}))
     uri = sheet["B2"].value
     cs = models.ConceptScheme(

--- a/src/voc4cat/transform.py
+++ b/src/voc4cat/transform.py
@@ -474,11 +474,7 @@ def _transform_xlsx(file, args):
         logger.debug("-> nothing to do for xlsx files!")
 
     # Extend size (length) of tables in all sheets
-    adjust_length_of_tables(
-        outfile,
-        rows_pre_allocated=config.xlsx_rows_pre_allocated
-    )
-
+    adjust_length_of_tables(outfile, rows_pre_allocated=config.xlsx_rows_pre_allocated)
 
 
 def _transform_rdf(file, args):

--- a/src/voc4cat/utils.py
+++ b/src/voc4cat/utils.py
@@ -85,7 +85,9 @@ def has_file_in_multiple_formats(dir_):
     return [x for x in file_names if x in seen or seen.add(x)]
 
 
-def adjust_length_of_tables(wb_path:Path, rows_pre_allocated:dict[str,int]|int=0, copy_style:bool=True) -> None:
+def adjust_length_of_tables(
+    wb_path: Path, rows_pre_allocated: dict[str, int] | int = 0, copy_style: bool = True
+) -> None:
     """Expand length of all tables in workbook to include all filled rows
 
     For all tables in the workbook the table is expanded to include the last
@@ -101,16 +103,19 @@ def adjust_length_of_tables(wb_path:Path, rows_pre_allocated:dict[str,int]|int=0
     to all following rows.
     """
     if isinstance(rows_pre_allocated, int):
-        rows_pre_allocated = {sheet: rows_pre_allocated for sheet in load_workbook(wb_path).sheetnames}
+        rows_pre_allocated = dict.fromkeys(
+            load_workbook(wb_path).sheetnames, rows_pre_allocated
+        )
     elif isinstance(rows_pre_allocated, dict):
         for sheet_name in load_workbook(wb_path).sheetnames:
             if sheet_name not in rows_pre_allocated:
-                rows_pre_allocated[sheet_name] = 0  # set default value for missing sheets
+                rows_pre_allocated[sheet_name] = (
+                    0  # set default value for missing sheets
+                )
     else:
         raise ValueError("rows_pre_allocated must be an int or a dict")
 
     wb = load_workbook(wb_path)
-
 
     for ws in wb.sheetnames:
         for t_name in list(wb[ws].tables):
@@ -124,7 +129,8 @@ def adjust_length_of_tables(wb_path:Path, rows_pre_allocated:dict[str,int]|int=0
             # find last row with content in table
             for row in range(1, end_row + 1):
                 row_has_content = any(
-                    wb[ws].cell(row=row, column=col).value for col in range(start_col, end_col + 1)
+                    wb[ws].cell(row=row, column=col).value
+                    for col in range(start_col, end_col + 1)
                 )
                 if not row_has_content:
                     break
@@ -151,7 +157,7 @@ def adjust_length_of_tables(wb_path:Path, rows_pre_allocated:dict[str,int]|int=0
                 # Read styles from first row
                 styles_in_row = []
                 for col in range(start_col, end_col + 1):
-                    cell = wb[ws].cell(row = start_row + 1, column = col)
+                    cell = wb[ws].cell(row=start_row + 1, column=col)
                     cell_styles = {}
                     for attr in ["alignment", "border", "font", "fill"]:
                         cell_styles[attr] = copy(getattr(cell, attr))
@@ -160,10 +166,12 @@ def adjust_length_of_tables(wb_path:Path, rows_pre_allocated:dict[str,int]|int=0
                 # Apply styles to all following rows
                 for row in range(start_row + 2, new_last_row + 1):
                     for col, cell_styles in enumerate(styles_in_row):
-                        cell = wb[ws].cell(row = row, column = start_col + col)
+                        cell = wb[ws].cell(row=row, column=start_col + col)
                         for style, styles_obj in cell_styles.items():
                             # Store indentation for sheet "Concepts", pref.label column
-                            keep_indent = (col == 1 and ws == "Concepts" and style == "alignment")
+                            keep_indent = (
+                                col == 1 and ws == "Concepts" and style == "alignment"
+                            )
                             if keep_indent and cell.alignment.indent:
                                 indent = cell.alignment.indent
                                 cell_alignment = copy(styles_obj)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -166,7 +166,7 @@ def test_validate_vocabulary_files_for_ci_workflow_single_vocab(
     with pytest.raises(Voc4catError) as excinfo:
         validate_vocabulary_files_for_ci_workflow(pr_vocab, pr_inbox)
     assert (
-        f'The file in inbox "{pr_inbox/inbox_file}" must match the vocabulary name "{Path(vocab_file).stem}".'
+        f'The file in inbox "{pr_inbox / inbox_file}" must match the vocabulary name "{Path(vocab_file).stem}".'
         in str(excinfo.value)
     )
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,7 +3,6 @@ import shutil
 from pathlib import Path
 
 import pytest
-from curies import Converter
 
 import voc4cat
 from tests.test_cli import (

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -130,7 +130,7 @@ def test_build_docs_no_input(tmp_path, caplog):
     """Check handling of of missing file or empty dir in documentation build."""
     with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
         main_cli(["docs", "--outdir", str(tmp_path), str(tmp_path / CS_CYCLES_TURTLE)])
-    assert f"File/dir not found: {tmp_path/CS_CYCLES_TURTLE}" in caplog.text
+    assert f"File/dir not found: {tmp_path / CS_CYCLES_TURTLE}" in caplog.text
 
     with caplog.at_level(logging.INFO):
         main_cli(["docs", "--outdir", str(tmp_path), str(tmp_path)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,10 +51,11 @@ def test_expand_tables(tmp_path, caplog):
     assert "from {A1:B3} to {A1:B5}" in caplog.text
     assert not ws["A3"].font.bold
 
-
     caplog.clear()
     # Test with expansion of table given rows beyond last data block row.
-    adjust_length_of_tables(test_wb, rows_pre_allocated=5) # adds 5 rows (default of rows_pre_allocated)
+    adjust_length_of_tables(
+        test_wb, rows_pre_allocated=5
+    )  # adds 5 rows (default of rows_pre_allocated)
     wb = load_workbook(test_wb)
     name, table_range = wb.active.tables.items()[0]
     assert name == "Table1"


### PR DESCRIPTION
More info on PEP 639 which is now well supported:
- https://peps.python.org/pep-0639/
- https://packaging.python.org/en/latest/specifications/core-metadata/

Other changes in this PR:
- Update pre-commit tools.
- Ruff is now also used for formatting (instead of black).
- Reformatting of several files due to the formatter upgrade