### PR TITLE
Tolerate tailing comma in multi-IRI cells

### DIFF
--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -42,6 +42,8 @@ def split_multi_iri(cell_value: str | None, prefix_converter: Converter) -> list
         return []
     iris_nomalised = []
     for line in cell_value.split(","):
+        if not line.strip():
+            continue
         iri = line.split()[0].strip()
         iris_nomalised.append(prefix_converter.expand(iri) or iri)
     return iris_nomalised

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -12,6 +12,7 @@ from tests.test_cli import (
 )
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
+from voc4cat.convert_043 import split_multi_iri
 
 
 @pytest.mark.parametrize(
@@ -102,3 +103,28 @@ def test_template(monkeypatch, datadir, tmp_path, caplog):
     with caplog.at_level(logging.INFO):
         main_cli(["convert", "-v", "--template", std_template, str(tmp_path)])
     assert "->" in caplog.text
+
+
+def test_split_multi_iri():
+    """Check the split_multi_iri function for various inputs."""
+
+    from curies import Converter
+
+    converter = Converter.from_prefix_map({"ex": "http://example.com/"})
+
+    assert split_multi_iri(
+        "http://example.com/iri1, http://example.com/iri2", prefix_converter=converter
+    ) == [
+        "http://example.com/iri1",
+        "http://example.com/iri2",
+    ]
+    assert split_multi_iri("http://example.com/iri1", prefix_converter=converter) == [
+        "http://example.com/iri1"
+    ]
+    assert split_multi_iri("ex:iri1", prefix_converter=converter) == [
+        "http://example.com/iri1"
+    ]
+    assert split_multi_iri("", prefix_converter=converter) == []
+    assert split_multi_iri("http://example.com/iri1,", prefix_converter=converter) == [
+        "http://example.com/iri1",
+    ]


### PR DESCRIPTION
With this PR tailing commas in cells like ChildrenIRIs will be ignored and will no longer raise an exception.

Closes #277