### PR TITLE
Accept optional xlsx template to provide extra sheets

### DIFF
--- a/src/voc4cat/cli.py
+++ b/src/voc4cat/cli.py
@@ -396,6 +396,13 @@ def add_template_subparser(subparsers, options):
         dest="template_version",  # avoid conflict with root --version
     )
     parser.add_argument(
+        "-t",
+        "--template",
+        help="An optionally-provided xlsx-template file to use as base.",
+        type=Path,
+        metavar="FILE",
+    )
+    parser.add_argument(
         "VOCAB",
         type=str,
         help="Vocabulary name used as the filename for the generated xlsx template.",

--- a/src/voc4cat/models_v1.py
+++ b/src/voc4cat/models_v1.py
@@ -232,6 +232,8 @@ class ConceptSchemeV1(BaseModel):
 
 # === Concepts (table format) ===
 
+CONCEPTS_SHEET_NAME = "Concepts"
+
 
 class ConceptV1(BaseModel):
     """Single concept row in the Concepts table."""
@@ -366,6 +368,8 @@ class ConceptV1(BaseModel):
 
 # === Collections (table format) ===
 
+COLLECTIONS_SHEET_NAME = "Collections"
+
 
 class CollectionV1(BaseModel):
     """Single collection row in the Collections table."""
@@ -450,6 +454,8 @@ class CollectionV1(BaseModel):
 
 
 # === Mappings (table format) ===
+
+MAPPINGS_SHEET_NAME = "Mappings"
 
 
 class MappingV1(BaseModel):
@@ -540,6 +546,18 @@ class PrefixV1(BaseModel):
 
 ID_RANGES_SHEET_NAME = "ID Ranges"
 ID_RANGES_SHEET_TITLE = "ID Ranges (read-only)"
+
+# Reserved sheet names (auto-created by voc4cat, not allowed in templates)
+RESERVED_SHEET_NAMES = frozenset(
+    {
+        CONCEPT_SCHEME_SHEET_NAME,
+        CONCEPTS_SHEET_NAME,
+        COLLECTIONS_SHEET_NAME,
+        MAPPINGS_SHEET_NAME,
+        ID_RANGES_SHEET_NAME,
+        PREFIXES_SHEET_NAME,
+    }
+)
 
 
 class IDRangeInfoV1(BaseModel):

--- a/src/voc4cat/utils.py
+++ b/src/voc4cat/utils.py
@@ -158,3 +158,110 @@ def adjust_length_of_tables(
 
     wb.save(wb_path)
     wb.close()
+
+
+# =============================================================================
+# Shared Template Utilities
+# =============================================================================
+
+
+def validate_template_sheets(template_path: Path) -> None:
+    """Validate that template doesn't contain reserved sheet names.
+
+    Args:
+        template_path: Path to the template xlsx file.
+
+    Raises:
+        Voc4catError: If template contains any reserved sheet names.
+    """
+    from voc4cat.checks import Voc4catError
+    from voc4cat.models_v1 import RESERVED_SHEET_NAMES
+
+    wb = load_workbook(template_path, read_only=True)
+    template_sheets = set(wb.sheetnames)
+    wb.close()
+
+    conflicting = template_sheets & RESERVED_SHEET_NAMES
+    if conflicting:
+        msg = (
+            f"Template contains reserved sheet names that will be auto-created: "
+            f'"{", ".join(sorted(conflicting))}". '
+            f"Please remove or rename these sheets in the template."
+        )
+        logger.error(msg)
+        raise Voc4catError(msg)
+
+
+def get_template_sheet_names(template_path: Path) -> list[str]:
+    """Get the list of sheet names from a template file.
+
+    Args:
+        template_path: Path to the template xlsx file.
+
+    Returns:
+        List of sheet names in the template, in their original order.
+    """
+    wb = load_workbook(template_path, read_only=True)
+    sheet_names = list(wb.sheetnames)
+    wb.close()
+    return sheet_names
+
+
+def reorder_sheets_with_template(
+    wb, template_sheet_names: list[str] | None = None
+) -> None:
+    """Reorder sheets: template sheets first (if any), then auto-created sheets.
+
+    Args:
+        wb: Workbook to reorder.
+        template_sheet_names: List of sheet names from template (in order).
+                             If provided, these sheets are placed first,
+                             followed by auto-created sheets.
+    """
+    from voc4cat.models_v1 import (
+        COLLECTIONS_SHEET_NAME,
+        CONCEPT_SCHEME_SHEET_NAME,
+        CONCEPTS_SHEET_NAME,
+        ID_RANGES_SHEET_NAME,
+        MAPPINGS_SHEET_NAME,
+        PREFIXES_SHEET_NAME,
+    )
+
+    auto_created_order = [
+        CONCEPT_SCHEME_SHEET_NAME,
+        CONCEPTS_SHEET_NAME,
+        COLLECTIONS_SHEET_NAME,
+        MAPPINGS_SHEET_NAME,
+        ID_RANGES_SHEET_NAME,
+        PREFIXES_SHEET_NAME,
+    ]
+
+    current_sheets = wb.sheetnames
+
+    if template_sheet_names is not None:
+        # Template sheets first (in original order), then auto-created
+        new_order = []
+        # First: template sheets in their original order
+        for sheet_name in template_sheet_names:
+            if sheet_name in current_sheets:
+                new_order.append(sheet_name)
+        # Second: auto-created sheets in expected order
+        for sheet_name in auto_created_order:
+            if sheet_name in current_sheets and sheet_name not in new_order:
+                new_order.append(sheet_name)
+        # Third: any remaining sheets (shouldn't happen, but defensive)
+        for sheet_name in current_sheets:
+            if sheet_name not in new_order:
+                new_order.append(sheet_name)
+    else:
+        # No template: auto-created first, then others
+        new_order = []
+        for sheet_name in auto_created_order:
+            if sheet_name in current_sheets:
+                new_order.append(sheet_name)
+        for sheet_name in current_sheets:
+            if sheet_name not in new_order:
+                new_order.append(sheet_name)
+
+    for idx, sheet_name in enumerate(new_order):
+        wb.move_sheet(sheet_name, offset=idx - wb.sheetnames.index(sheet_name))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -69,3 +69,109 @@ def test_template(monkeypatch, datadir, tmp_path, caplog):
     with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
         main_cli(["convert", "--template", "template.txt", str(tmp_path)])
     assert 'Template file must be of type ".xlsx".' in caplog.text
+
+
+def test_template_with_conflicting_sheets(monkeypatch, datadir, tmp_path, caplog):
+    """Check that templates with reserved sheet names are rejected."""
+    from openpyxl import Workbook
+
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(datadir / CS_CYCLES_TURTLE, tmp_path)
+
+    # Create template with a reserved sheet name
+    wb = Workbook()
+    wb.active.title = "Branding"  # OK - not reserved
+    wb.create_sheet("Concepts")  # CONFLICT - reserved name
+    template_path = tmp_path / "bad_template.xlsx"
+    wb.save(template_path)
+    wb.close()
+
+    with caplog.at_level(logging.ERROR), pytest.raises(Voc4catError):
+        main_cli(["convert", "--template", str(template_path), str(tmp_path)])
+
+    assert "reserved sheet names" in caplog.text
+    assert "Concepts" in caplog.text
+
+
+def test_template_sheets_preserved_and_ordered(
+    monkeypatch, datadir, tmp_path, temp_config
+):
+    """Check that template sheets are preserved and placed first."""
+    from openpyxl import Workbook, load_workbook
+
+    monkeypatch.chdir(tmp_path)
+    vocab_dir = tmp_path / "vocab"
+    vocab_dir.mkdir()
+    shutil.copy(datadir / CS_CYCLES_TURTLE, vocab_dir)
+
+    # Create valid template with branding sheets (outside vocab_dir)
+    wb = Workbook()
+    wb.active.title = "Cover"
+    wb.create_sheet("Instructions")
+    wb.create_sheet("Help")
+    template_path = tmp_path / "branding_template.xlsx"
+    wb.save(template_path)
+    wb.close()
+
+    # Set up config for the vocabulary (name matches input file stem)
+    config = temp_config
+    vocab_name = "concept-scheme-with-cycles"
+    config.CURIES_CONVERTER_MAP[vocab_name] = config.curies_converter
+
+    main_cli(["convert", "--template", str(template_path), str(vocab_dir)])
+
+    # Check output (name matches input file stem)
+    output_path = vocab_dir / "concept-scheme-with-cycles.xlsx"
+    assert output_path.exists()
+
+    result_wb = load_workbook(output_path)
+    sheets = result_wb.sheetnames
+
+    # Template sheets should come first
+    assert sheets[0] == "Cover"
+    assert sheets[1] == "Instructions"
+    assert sheets[2] == "Help"
+
+    # Auto-created sheets should follow
+    assert "Concept Scheme" in sheets
+    assert "Concepts" in sheets
+    assert "Collections" in sheets
+    assert "Mappings" in sheets
+    assert "ID Ranges" in sheets
+    assert "Prefixes" in sheets
+
+    # Verify order: template sheets before auto-created
+    cover_idx = sheets.index("Cover")
+    cs_idx = sheets.index("Concept Scheme")
+    assert cover_idx < cs_idx
+
+    result_wb.close()
+
+
+def test_template_warning_for_xlsx_input(
+    monkeypatch, datadir, tmp_path, caplog, cs_cycles_xlsx
+):
+    """Check that a warning is logged when template is used with xlsx input."""
+    from openpyxl import Workbook
+
+    monkeypatch.chdir(tmp_path)
+    vocab_dir = tmp_path / "vocab"
+    vocab_dir.mkdir()
+    shutil.copy(cs_cycles_xlsx, vocab_dir / CS_CYCLES)
+
+    # Create a valid template (outside vocab_dir)
+    wb = Workbook()
+    wb.active.title = "Branding"
+    template_path = tmp_path / "template.xlsx"
+    wb.save(template_path)
+    wb.close()
+
+    # The conversion may fail for other reasons (missing config), but the warning
+    # should be logged before that happens
+    with caplog.at_level(logging.WARNING):
+        try:
+            main_cli(["convert", "--template", str(template_path), str(vocab_dir)])
+        except Voc4catError:
+            pass  # Expected - conversion needs config, but warning comes first
+
+    assert "Template option ignored for xlsx->RDF conversion" in caplog.text


### PR DESCRIPTION
The 0.10.x series required to supply an xlsx template. This could be used to create a customized vocabulary xlsx with vocabulary specific Information- or Help-sheet.

This PR add this function to v1.0 voc4cat which auto-generate all vocabulary sheets. The supplied PR may only contain sheets that are not auto-generated. How to use?

```bash
voc4cat template --template myvocab_help.xlsx myvocab
```
or
```bash
voc4cat convert --template myvocab_help.xlsx myvocab.ttl
```