### PR TITLE
Fix historyNote for CS, schema.org entities, and ttl-splitting in v1.0

### DIFF
--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -113,6 +113,7 @@ class Vocab(BaseModel):
     provenance_url_template: str = ""  # Jinja template for provenance (git blame) URLs
     homepage: str = ""
     conforms_to: str = ""
+    history_note: str = ""  # Auto-generated if empty: "Created {date} by {names}."
     profile_local_path: str = (
         ""  # Path to SHACL profile file, relative to idranges.toml
     )

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -155,7 +155,7 @@ def _enrich_concept_scheme_from_config(
         (DCTERMS.created, "created_date", True, XSD.date),
         (DCTERMS.modified, "modified_date", True, XSD.date),
         (OWL.versionInfo, "version", True, None),
-        (SKOS.historyNote, "change_note", True, "en"),
+        (SKOS.historyNote, "history_note", True, "en"),
         (DCAT.contactPoint, "custodian", True, None),
     ]
 

--- a/src/voc4cat/convert_v1_helpers.py
+++ b/src/voc4cat/convert_v1_helpers.py
@@ -54,6 +54,69 @@ def expand_curie(curie_or_iri: str, converter: curies.Converter) -> str:
 
 
 # =============================================================================
+# Creator Field Utilities
+# =============================================================================
+
+
+def extract_creator_names(creator_field: str) -> list[str]:
+    """Extract names from creator field.
+
+    The creator field format is '<URL> <name>' per line, where URL is an
+    ORCID or ROR identifier.
+
+    Examples:
+        'https://orcid.org/0000-0001-2345-6789 John Doe\\n...' -> ['John Doe', ...]
+
+    Args:
+        creator_field: Multi-line string with creator entries.
+
+    Returns:
+        List of extracted names (empty list if no names found).
+    """
+    if not creator_field:
+        return []
+
+    names = []
+    for line in creator_field.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        # Split by whitespace - name is everything after the URL
+        parts = line.split()
+        # Find the URL (starts with http) and take everything after it
+        for i, part in enumerate(parts):
+            if part.startswith("http"):
+                name = " ".join(parts[i + 1 :])
+                if name:
+                    names.append(name)
+                break
+    return names
+
+
+def generate_history_note(created_date: str, creator_names: list[str]) -> str:
+    """Generate a history note from creation date and creator names.
+
+    Format: "Created {date}." or "Created {date} by {name1}, {name2}."
+
+    Args:
+        created_date: Creation date string (e.g., "2025" or "2025-01-15").
+        creator_names: List of creator names.
+
+    Returns:
+        Generated history note, or empty string if no created_date.
+    """
+    if not created_date:
+        return ""
+
+    note = f"Created {created_date}"
+    if creator_names:
+        names_str = ", ".join(creator_names)
+        note += f" by {names_str}"
+    note += "."
+    return note
+
+
+# =============================================================================
 # Provenance URL Helpers
 # =============================================================================
 

--- a/src/voc4cat/models_v1.py
+++ b/src/voc4cat/models_v1.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 from voc4cat.xlsx_common import XLSXMetadata
 
-TEMPLATE_VERSION = "1.0.rev-2025-06a"
+TEMPLATE_VERSION = "v1.0.rev-2025-12a"
 
 
 # === Obsoletion Reason Enums ===
@@ -153,12 +153,12 @@ class ConceptSchemeV1(BaseModel):
         ),
     ] = ""
 
-    change_note: Annotated[
+    history_note: Annotated[
         str,
         XLSXMetadata(
-            display_name="Change Note",
-            description="A note on the Vocabulary source",
-            meaning="skos:changeNote",
+            display_name="History Note",
+            description="A note on the source or history of this vocabulary.",
+            meaning="skos:historyNote",
         ),
     ] = ""
 

--- a/tests/test_roundtrip_v1.py
+++ b/tests/test_roundtrip_v1.py
@@ -1009,8 +1009,8 @@ def test_roundtrip_full_vocabulary_isomorphic(
             # but Keep hasTopConcept relationships
             if exclude_scheme_triples and s == scheme_iri and p != SKOS.hasTopConcept:
                 continue
-            # Skip Organization triples (auto-generated from config creator/publisher)
-            if (s, RDF.type, SDO.Organization) in g:
+            # Skip Person/Organization triples (auto-generated from config creator/publisher)
+            if (s, RDF.type, SDO.Organization) in g or (s, RDF.type, SDO.Person) in g:
                 continue
             filtered.add((s, p, o))
         return filtered

--- a/tests/test_xlsx_integration.py
+++ b/tests/test_xlsx_integration.py
@@ -12,6 +12,7 @@ from typing import Annotated
 import pytest
 from pydantic import BaseModel, Field
 
+from voc4cat.models_v1 import TEMPLATE_VERSION
 from voc4cat.xlsx_api import XLSXProcessorFactory, export_to_xlsx, import_from_xlsx
 from voc4cat.xlsx_common import XLSXConverters, XLSXMetadata
 from voc4cat.xlsx_keyvalue import XLSXKeyValueConfig
@@ -60,7 +61,7 @@ class ConceptScheme(BaseModel):
             meaning="dcterms:hasVersion",
             description="Gets increments only on structural changes. Its general pattern is major.minor.rev-JJJJ-MM[a-z].",
         ),
-    ] = Field(default="1.0.rev-2025-06a")
+    ] = Field(default=TEMPLATE_VERSION)
 
     vocabulary_iri: Annotated[
         str,


### PR DESCRIPTION
- Contributor/custodian now generate entity definitions
- extract_concept_scheme_from_rdf() now supports multiple creators/ publishers
- Added lookup_entity_name() to reconstruct "name url" format from schema:name
- history_note field now auto-generated when not given via config
- schema:Person and schema:Organization entities now included in concept_scheme.ttl during split