### PR TITLE
Add partitioning: Store vocabularies into subdirectories by ID range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+Features:
+
+- **Partitioned split structure:** The `--split` option now organizes concept files into subdirectories by ID range (1000 IDs per directory, e.g., `IDs0001xxx/`). This avoids GitHub UI limitations with large directories. The `--join` option supports both the new partitioned structure and the previous flat structure.
+
 ## Release 1.0.0 (RC2) (2025-12-27)
 
 The following changes were made to RC1 based on testing it with the voc4cat vocabulary and Skosmos 3.0.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -117,14 +117,19 @@ voc4cat transform [options] VOCAB
 
 ### Split/Join workflow
 
-Large turtle files produce difficult-to-review git diffs. The split format stores each concept in a separate file, making changes easier to review:
+Large turtle files produce difficult-to-review git diffs. The split format stores each concept in a separate file, making changes easier to review.
+
+Concepts are partitioned into subdirectories by ID range (1000 IDs per directory) to avoid GitHub UI limitations with large directories:
 
 ```
 vocabularies/myvocab/
 ├── concept_scheme.ttl
-├── 0001001.ttl
-└── 0001002.ttl
+└── IDs0001xxx/
+    ├── 0001001.ttl
+    └── 0001002.ttl
 ```
+
+The directory name padding matches the vocabulary's `id_length` setting (e.g., `IDs0001xxx` for 7-digit IDs, `IDs001xxx` for 6-digit IDs).
 
 The voc4cat-template workflows use split format for storage and join files when needed for documentation or export.
 

--- a/src/voc4cat/check.py
+++ b/src/voc4cat/check.py
@@ -126,7 +126,7 @@ def ci_post(args):
         if (
             prev_split_voc.exists()
             and prev_split_voc.is_dir()
-            and any(prev_split_voc.glob("*.ttl"))
+            and any(prev_split_voc.rglob("*.ttl"))
         ):
             # Create a single vocab out of the directory
             logger.debug("-> previous version is a split vocabulary, joining...")

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -9,7 +9,7 @@ from rdflib import DCTERMS, OWL, SKOS, XSD, Graph, Literal
 from tests.test_cli import CS_CYCLES
 from voc4cat.checks import Voc4catError
 from voc4cat.cli import main_cli
-from voc4cat.transform import _run_git
+from voc4cat.transform import _run_git, get_partition_dir_name
 
 CS_SIMPLE_TURTLE = "concept-scheme-simple.ttl"
 
@@ -62,7 +62,7 @@ def test_split(monkeypatch, datadir, tmp_path, opt, caplog):
     vocdir = (tmp_path / CS_SIMPLE_TURTLE).with_suffix("")
     assert vocdir.is_dir()
     assert (vocdir / "concept_scheme.ttl").exists()
-    assert len([*vocdir.glob("*.ttl")]) == 8
+    assert len([*vocdir.rglob("*.ttl")]) == 8  # Use rglob for partitioned structure
     if opt:
         assert not (tmp_path / CS_SIMPLE_TURTLE).exists()
 
@@ -204,7 +204,8 @@ def test_prov_from_git_adds_dates(git_repo_with_split_files, monkeypatch, caplog
     assert "-> added provenance from git to" in caplog.text
 
     # Check that dct:created and dct:modified were added to a concept file
-    concept_files = [f for f in vocdir.glob("*.ttl") if f.name != "concept_scheme.ttl"]
+    # Use rglob to find files in partitioned subdirectories
+    concept_files = [f for f in vocdir.rglob("*.ttl") if f.name != "concept_scheme.ttl"]
     assert len(concept_files) > 0
 
     graph = Graph().parse(concept_files[0], format="turtle")
@@ -277,7 +278,8 @@ def test_prov_from_git_preserves_existing_created(
     main_cli(["transform", "--prov-from-git", "--inplace", str(vocdir)])
 
     # Modify a file to add a custom dct:created date
-    concept_files = [f for f in vocdir.glob("*.ttl") if f.name != "concept_scheme.ttl"]
+    # Use rglob to find files in partitioned subdirectories
+    concept_files = [f for f in vocdir.rglob("*.ttl") if f.name != "concept_scheme.ttl"]
     test_file = concept_files[0]
     graph = Graph().parse(test_file, format="turtle")
 
@@ -311,7 +313,8 @@ def test_prov_from_git_updates_modified(git_repo_with_split_files, monkeypatch, 
 
     # Manually set a different dct:modified date in the file
     # (simulating an old date that differs from the current git modified date)
-    concept_files = [f for f in vocdir.glob("*.ttl") if f.name != "concept_scheme.ttl"]
+    # Use rglob to find files in partitioned subdirectories
+    concept_files = [f for f in vocdir.rglob("*.ttl") if f.name != "concept_scheme.ttl"]
     test_file = concept_files[0]
     graph = Graph().parse(test_file, format="turtle")
 
@@ -369,16 +372,18 @@ def test_prov_from_git_with_outdir(git_repo_with_split_files, monkeypatch, caplo
     assert (target_dir / "concept_scheme.ttl").exists()
 
     # Check that original files were NOT modified (no dct:created/modified)
+    # Use rglob to find files in partitioned subdirectories
     original_concept_files = [
-        f for f in vocdir.glob("*.ttl") if f.name != "concept_scheme.ttl"
+        f for f in vocdir.rglob("*.ttl") if f.name != "concept_scheme.ttl"
     ]
     graph_original = Graph().parse(original_concept_files[0], format="turtle")
     concept_iri = next(iter(graph_original.subjects(None, SKOS.Concept)))
     assert len(list(graph_original.objects(concept_iri, DCTERMS.created))) == 0
 
     # Check that copied files HAVE dct:created/modified
+    # Use rglob to find files in partitioned subdirectories
     copied_concept_files = [
-        f for f in target_dir.glob("*.ttl") if f.name != "concept_scheme.ttl"
+        f for f in target_dir.rglob("*.ttl") if f.name != "concept_scheme.ttl"
     ]
     graph_copied = Graph().parse(copied_concept_files[0], format="turtle")
     concept_iri_copied = next(iter(graph_copied.subjects(None, SKOS.Concept)))
@@ -397,7 +402,8 @@ def test_prov_from_git_parent_directory(git_repo_with_split_files, monkeypatch, 
     assert "-> added provenance from git to" in caplog.text
 
     # Check that dct:created and dct:modified were added to a concept file
-    concept_files = [f for f in vocdir.glob("*.ttl") if f.name != "concept_scheme.ttl"]
+    # Use rglob to find files in partitioned subdirectories
+    concept_files = [f for f in vocdir.rglob("*.ttl") if f.name != "concept_scheme.ttl"]
     assert len(concept_files) > 0
 
     graph = Graph().parse(concept_files[0], format="turtle")
@@ -412,3 +418,150 @@ def test_prov_from_git_parent_directory(git_repo_with_split_files, monkeypatch, 
     # Check dct:modified exists
     modified_values = list(graph.objects(concept_iri, DCTERMS.modified))
     assert len(modified_values) == 1
+
+
+# ===== Tests for partitioned split structure =====
+
+
+@pytest.mark.parametrize(
+    ("numeric_id", "id_length", "expected"),
+    [
+        # 7-digit IDs (default)
+        ("0000000", 7, "IDs0000xxx"),
+        ("0000001", 7, "IDs0000xxx"),
+        ("0000042", 7, "IDs0000xxx"),
+        ("0000999", 7, "IDs0000xxx"),
+        ("0001000", 7, "IDs0001xxx"),
+        ("0001001", 7, "IDs0001xxx"),
+        ("0001500", 7, "IDs0001xxx"),
+        ("0001999", 7, "IDs0001xxx"),
+        ("0002000", 7, "IDs0002xxx"),
+        ("0007017", 7, "IDs0007xxx"),
+        ("0999999", 7, "IDs0999xxx"),
+        # 6-digit IDs
+        ("000000", 6, "IDs000xxx"),
+        ("000001", 6, "IDs000xxx"),
+        ("000042", 6, "IDs000xxx"),
+        ("000999", 6, "IDs000xxx"),
+        ("001000", 6, "IDs001xxx"),
+        ("001500", 6, "IDs001xxx"),
+        ("007017", 6, "IDs007xxx"),
+        # 5-digit IDs
+        ("00000", 5, "IDs00xxx"),
+        ("00042", 5, "IDs00xxx"),
+        ("00999", 5, "IDs00xxx"),
+        ("01000", 5, "IDs01xxx"),
+        # Edge case: empty string
+        ("", 7, "IDs0000xxx"),
+    ],
+)
+def test_get_partition_dir_name(numeric_id, id_length, expected):
+    """Test partition directory name calculation for various ID lengths."""
+    assert get_partition_dir_name(numeric_id, id_length) == expected
+
+
+def test_split_creates_partitioned_structure(monkeypatch, datadir, tmp_path, caplog):
+    """Test that split creates IDs{NNN}xxx subdirectories based on ID ranges."""
+    shutil.copy(datadir / CS_SIMPLE_TURTLE, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["transform", "-v", "--split", "--inplace", str(tmp_path)])
+    assert "-> wrote split vocabulary to" in caplog.text
+
+    vocdir = (tmp_path / CS_SIMPLE_TURTLE).with_suffix("")
+    assert vocdir.is_dir()
+
+    # concept_scheme.ttl should be in root
+    assert (vocdir / "concept_scheme.ttl").exists()
+
+    # Concept files should be in partition subdirectories
+    # The test data has concepts with small IDs (01-06) and a collection (10)
+    # All should be in IDs0000xxx for 7-digit IDs (default)
+    partition_dir = vocdir / "IDs0000xxx"
+    assert partition_dir.is_dir()
+
+    # Count total .ttl files (should be same as before: concept_scheme + 7 entities)
+    all_ttl_files = list(vocdir.rglob("*.ttl"))
+    assert len(all_ttl_files) == 8
+
+    # concept_scheme.ttl in root, 7 entity files in partition dir
+    assert len(list(partition_dir.glob("*.ttl"))) == 7
+
+
+def test_join_partitioned_structure(monkeypatch, datadir, tmp_path, caplog):
+    """Test that join works with partitioned IDs{NNN}xxx subdirectory structure."""
+    shutil.copy(datadir / CS_SIMPLE_TURTLE, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # First split to create partitioned structure
+    main_cli(["transform", "-v", "--split", "--inplace", str(tmp_path)])
+
+    vocdir = (tmp_path / CS_SIMPLE_TURTLE).with_suffix("")
+
+    # Verify partitioned structure was created
+    partition_dir = vocdir / "IDs0000xxx"
+    assert partition_dir.is_dir()
+
+    # Now join the partitioned structure
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["transform", "-v", "--join", "--inplace", str(tmp_path)])
+    assert "-> joined vocabulary into" in caplog.text
+
+    # The split directory should be removed (--inplace)
+    assert not vocdir.exists()
+
+    # The joined file should exist
+    assert (tmp_path / CS_SIMPLE_TURTLE).exists()
+
+    # Verify the joined file contains all expected content
+    graph = Graph().parse(tmp_path / CS_SIMPLE_TURTLE, format="turtle")
+    concepts = list(graph.subjects(None, SKOS.Concept))
+    collections = list(graph.subjects(None, SKOS.Collection))
+    schemes = list(graph.subjects(None, SKOS.ConceptScheme))
+
+    # Original test data has 6 concepts, 1 collection, 1 concept scheme
+    assert len(concepts) == 6
+    assert len(collections) == 1
+    assert len(schemes) == 1
+
+
+def test_join_flat_structure_backward_compat(monkeypatch, datadir, tmp_path, caplog):
+    """Test that join still works with old flat structure (backward compatibility)."""
+    shutil.copy(datadir / CS_SIMPLE_TURTLE, tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Create a flat structure manually (simulate old format)
+    vocdir = tmp_path / "flat-vocab"
+    vocdir.mkdir()
+
+    # Parse the source file and create flat split manually
+    source_graph = Graph().parse(tmp_path / CS_SIMPLE_TURTLE, format="turtle")
+
+    # Extract concept scheme
+    cs_graph = Graph()
+    for cs_iri in source_graph.subjects(None, SKOS.ConceptScheme):
+        for triple in source_graph.triples((cs_iri, None, None)):
+            cs_graph.add(triple)
+    cs_graph.serialize(destination=vocdir / "concept_scheme.ttl", format="turtle")
+
+    # Extract concepts (flat, no subdirectories)
+    for concept_iri in source_graph.subjects(None, SKOS.Concept):
+        concept_graph = Graph()
+        for triple in source_graph.triples((concept_iri, None, None)):
+            concept_graph.add(triple)
+        # Extract ID from IRI for filename
+        iri_str = str(concept_iri)
+        numeric_id = "".join(c for c in reversed(iri_str) if c.isdigit())[::-1]
+        if numeric_id:
+            concept_graph.serialize(
+                destination=vocdir / f"{numeric_id}.ttl", format="turtle"
+            )
+
+    # Now join the flat structure
+    with caplog.at_level(logging.DEBUG):
+        main_cli(["transform", "-v", "--join", str(tmp_path)])
+    assert "-> joined vocabulary into" in caplog.text
+
+    # The joined file should exist
+    assert (tmp_path / "flat-vocab.ttl").exists()


### PR DESCRIPTION
Vocabularies with more than 1000 concepts cause GitHub UI issues. This change partitions concept files into subdirectories based on ID ranges (1000 IDs per directory).

  Changes:
  - --split now creates IDs{NNN}xxx/ subdirectories (e.g., IDs0000xxx/, IDs0001xxx/)
  - Directory name padding matches vocabulary's id_length from config (7-digit → 4-digit prefix, 6-digit → 3-digit prefix)
  - concept_scheme.ttl remains in vocabulary root
  - --join supports both old flat structure and new partitioned structure (backward compatible)
  - --prov-from-git works with nested directories

```
  Example structure (7-digit IDs):
  vocab1/
    IDs0000xxx/
      0000001.ttl
      0000999.ttl
    IDs0001xxx/
      0001000.ttl
    concept_scheme.ttl
```