### PR TITLE
Change dependabot to group updates to a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# This configures updates via dependabot only for github actions.
+# All updates are grouped into a single PR.
+
 version: 2
 updates:
 - package-ecosystem: github-actions
@@ -6,3 +9,9 @@ updates:
     interval: monthly
   assignees:
     - "dalito"
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+
+# Ref: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates


### PR DESCRIPTION
To reduce monthly work on dependabot updates. 

We should do this also in the other repos if it works well.