### PR TITLE
Fix ID length validation: reject IDs with wrong digit count

### DIFF
--- a/src/voc4cat/config.py
+++ b/src/voc4cat/config.py
@@ -232,7 +232,9 @@ def load_config(config_file: Path | None = None, config: IDrangeConfig | None = 
     id_patterns = {}
     for name in new_conf["IDRANGES"].vocabs:
         voc = new_conf["IDRANGES"].vocabs.get(name)
-        id_patterns[name] = re.compile(r"(?P<identifier>[0-9]{%i})$" % voc.id_length)  # noqa: UP031
+        id_patterns[name] = re.compile(
+            r"(?<![0-9])(?P<identifier>[0-9]{%i})$" % voc.id_length
+        )  # noqa: UP031
     new_conf["ID_PATTERNS"] = id_patterns
 
     new_conf["ID_RANGES_BY_ACTOR"] = _id_ranges_by_actor(new_conf)

--- a/src/voc4cat/convert_043.py
+++ b/src/voc4cat/convert_043.py
@@ -386,7 +386,9 @@ def convert_rdf_043_to_v1(
     id_pattern = config.ID_PATTERNS.get(vocab_name)
     if not id_pattern and vocab_config:
         # Fall back to compiling pattern from vocab_config.id_length
-        id_pattern = re.compile(rf"(?P<identifier>[0-9]{{{vocab_config.id_length}}})$")
+        id_pattern = re.compile(
+            rf"(?<![0-9])(?P<identifier>[0-9]{{{vocab_config.id_length}}})$"
+        )
 
     # Process each triple
     for s, p, o in input_graph:

--- a/src/voc4cat/convert_v1_helpers.py
+++ b/src/voc4cat/convert_v1_helpers.py
@@ -381,7 +381,7 @@ def extract_used_ids(
     # Build regex pattern for extracting numeric IDs
     # IDs are at the end of the IRI and have a fixed length
     id_length = vocab_config.id_length
-    pattern = re.compile(rf"(\d{{{id_length}}})$")
+    pattern = re.compile(rf"(?<!\d)(\d{{{id_length}}})$")
 
     # Get permanent IRI part for filtering
     permanent_iri = str(vocab_config.permanent_iri_part).rstrip("/")
@@ -408,6 +408,12 @@ def extract_used_ids(
         match = pattern.search(expanded_iri)
         if match:
             used_ids.add(int(match.group(1)))
+        else:
+            logger.warning(
+                "IRI belongs to vocabulary but does not match ID pattern '%s': %s",
+                pattern.pattern,
+                expanded_iri,
+            )
 
     # Process collections - extract from collection_iri field
     seen_iris.clear()
@@ -428,6 +434,12 @@ def extract_used_ids(
         match = pattern.search(expanded_iri)
         if match:
             used_ids.add(int(match.group(1)))
+        else:
+            logger.warning(
+                "IRI belongs to vocabulary but does not match ID pattern '%s': %s",
+                pattern.pattern,
+                expanded_iri,
+            )
 
     return used_ids
 


### PR DESCRIPTION
Add negative lookbehind to ID regex patterns so that e.g. an 8-digit ID is not silently accepted by a 7-digit pattern. Abort conversion when non-conforming IDs are found.

With this PR conversion fails with a meaningful message:

```bash
INFO    |Executing cmd: voc4cat convert --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --outdir outbox inbox-excel-vocabs/
INFO    |Reading XLSX file: inbox-excel-vocabs\voc4cat.xlsx
ERROR   |Terminating with error: Found 19 non-conforming IRI(s) that do not match the configured ID pattern ((?<![0-9])(?P<identifier>[0-9]{7})$):
  https://w3id.org/nfdi4cat/voc4cat_00008201
  https://w3id.org/nfdi4cat/voc4cat_00008202
```

Closes #341